### PR TITLE
correctie url in openapi specs

### DIFF
--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -4,7 +4,7 @@
     "title" : "BRP bewoning",
     "description" : "API voor het raadplegen van de (historische) bewoning van een adres of de medebewoners van een persoon.\n",
     "contact" : {
-      "url" : "https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bewoning"
+      "url" : "https://github.com/BRP-API/Haal-Centraal-BRP-bewoning"
     },
     "license" : {
       "name" : "European Union Public License, version 1.2 (EUPL-1.2)",

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -12,6 +12,10 @@
     },
     "version" : "2.0.0"
   },
+  "externalDocs" : {
+    "description" : "Haal Centraal BRP bewoning website",
+    "url" : "https://brp-api.github.io/Haal-Centraal-BRP-bewoning/"
+  },
   "servers" : [ {
     "url" : "/"
   } ],

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -4,7 +4,7 @@ info:
   description: |
     API voor het raadplegen van de (historische) bewoning van een adres of de medebewoners van een persoon.
   contact:
-    url: https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bewoning
+    url: https://github.com/BRP-API/Haal-Centraal-BRP-bewoning
   license:
     name: "European Union Public License, version 1.2 (EUPL-1.2)"
     url: https://eupl.eu/1.2/nl/

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -9,6 +9,9 @@ info:
     name: "European Union Public License, version 1.2 (EUPL-1.2)"
     url: https://eupl.eu/1.2/nl/
   version: 2.0.0
+externalDocs:
+  description: Haal Centraal BRP bewoning website
+  url: https://brp-api.github.io/Haal-Centraal-BRP-bewoning/
 servers:
 - url: /
 tags:

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -11,7 +11,7 @@ info:
     url: https://eupl.eu/1.2/nl/
 tags:
   - name: Bewoning
-externaldocs:
+externalDocs:
   description: Haal Centraal BRP bewoning website
   url: https://brp-api.github.io/Haal-Centraal-BRP-bewoning/
 paths:

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -5,12 +5,15 @@ info:
     API voor het raadplegen van de (historische) bewoning van een adres of de medebewoners van een persoon.
   version: 2.0.0
   contact:
-    url: https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bewoning
+    url: https://github.com/BRP-API/Haal-Centraal-BRP-bewoning
   license:
     name: European Union Public License, version 1.2 (EUPL-1.2)
     url: https://eupl.eu/1.2/nl/
 tags:
   - name: Bewoning
+externaldocs:
+  description: Haal Centraal BRP bewoning website
+  url: https://brp-api.github.io/Haal-Centraal-BRP-bewoning/
 paths:
   /bewoningen:
     post:


### PR DESCRIPTION
er werd nog verwezen naar de VNG GitHub