### PR TITLE
Feature/bewoning onbekend

### DIFF
--- a/features/raadpleeg-bewoning-op-peildatum/gba/geheimhouding-gba.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/gba/geheimhouding-gba.feature
@@ -30,6 +30,7 @@ Rule: indicatie geheim waarde 0 wordt niet geleverd
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-09-01 tot 2010-09-02 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-09-01 tot 2010-09-02' een bewoner met de volgende gegevens
@@ -53,6 +54,7 @@ Rule: indicatie geheim waarde 0 wordt niet geleverd
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-08-18 tot 2010-08-19 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-08-18 tot 2010-08-19' een mogelijke bewoner met de volgende gegevens
@@ -78,6 +80,7 @@ Rule: indicatie geheim met waarde hoger dan 0 wordt vertaald naar geheimhoudingP
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-09-01 tot 2010-09-02 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-09-01 tot 2010-09-02' een bewoner met de volgende gegevens
@@ -111,6 +114,7 @@ Rule: indicatie geheim met waarde hoger dan 0 wordt vertaald naar geheimhoudingP
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-08-18 tot 2010-08-19 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-08-18 tot 2010-08-19' een mogelijke bewoner met de volgende gegevens

--- a/features/raadpleeg-bewoning-op-peildatum/gba/in-onderzoek-gba.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/gba/in-onderzoek-gba.feature
@@ -21,6 +21,7 @@ Rule: het in onderzoek zijn van de 'identificatiecode verblijfplaats' en/of 'dat
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2020-04-15 tot 2020-04-16 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2020-04-15 tot 2020-04-16' een bewoner met de volgende gegevens
@@ -61,6 +62,7 @@ Rule: datum ingang onderzoek is niet relevant voor het wel/niet leveren van het 
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' een bewoner met de volgende gegevens
@@ -86,6 +88,7 @@ Rule: een beëindigd onderzoek wordt nooit vertaald naar indicatieVerblijfsplaat
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' een bewoner met de volgende gegevens
@@ -98,4 +101,3 @@ Rule: een beëindigd onderzoek wordt nooit vertaald naar indicatieVerblijfsplaat
     | 2020-04-01 | 2020-04-01 tot 2020-04-02 | peildatum ligt op datum ingang onderzoek                               |
     | 2020-05-01 | 2020-05-01 tot 2020-05-02 | peildatum ligt na datum ingang onderzoek en vóór datum einde onderzoek |
     | 2020-08-01 | 2020-08-01 tot 2020-08-02 | peildatum ligt na datum einde onderzoek                                |
-  

--- a/features/raadpleeg-bewoning-op-peildatum/gba/opschorting-bijhouding-gba.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/gba/opschorting-bijhouding-gba.feature
@@ -24,6 +24,7 @@ Rule: personen met een afgevoerde persoonslijst worden niet gezien als bewoner
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-09-01 tot 2010-09-02 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-09-01 tot 2010-09-02' geen bewoners
@@ -44,6 +45,7 @@ Rule: personen op een logisch verwijderde persoonslijst worden niet gezien als b
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-09-01 tot 2010-09-02 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-09-01 tot 2010-09-02' geen bewoners
@@ -64,6 +66,7 @@ Rule: personen met opschorting bijhouding met aanduiding ongelijk aan "F" of "W"
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2022-08-28 tot 2022-08-29 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2022-08-28 tot 2022-08-29' een bewoner met de volgende gegevens
@@ -92,6 +95,7 @@ Rule: personen met opschorting bijhouding met aanduiding ongelijk aan "F" of "W"
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' geen bewoners

--- a/features/raadpleeg-bewoning-op-peildatum/gba/overzicht-gba.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/gba/overzicht-gba.feature
@@ -33,6 +33,7 @@ Rule: een persoon is bewoner van een adresseerbaar object op een peildatum als:
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' een bewoner met de volgende gegevens
@@ -59,6 +60,7 @@ Rule: een persoon is bewoner van een adresseerbaar object op een peildatum als:
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' geen bewoners
@@ -85,6 +87,7 @@ Rule: een persoon is bewoner van een adresseerbaar object op een peildatum als:
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' bewoners met de volgende gegevens
@@ -113,6 +116,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' een mogelijke bewoner met de volgende gegevens
@@ -136,6 +140,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-09-01 tot 2010-09-02 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-09-01 tot 2010-09-02' een bewoner met de volgende gegevens
@@ -153,6 +158,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-07-31 tot 2010-08-01 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-07-31 tot 2010-08-01' geen bewoners
@@ -171,6 +177,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' een mogelijke bewoner met de volgende gegevens
@@ -197,6 +204,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2016-06-01 tot 2016-06-02 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2016-06-01 tot 2016-06-02' geen bewoners
@@ -215,6 +223,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2016-04-30 tot 2016-05-01 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2016-04-30 tot 2016-05-01' een bewoner met de volgende gegevens
@@ -232,6 +241,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' een mogelijke bewoner met de volgende gegevens
@@ -255,6 +265,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2011-01-01 tot 2011-01-02 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2011-01-01 tot 2011-01-02' een bewoner met de volgende gegevens
@@ -272,6 +283,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2009-12-31 tot 2010-01-01 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2009-12-31 tot 2010-01-01' geen bewoners
@@ -290,6 +302,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' een mogelijke bewoner met de volgende gegevens
@@ -316,6 +329,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2017-01-01 tot 2017-01-02 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2017-01-01 tot 2017-01-02' geen bewoners
@@ -334,6 +348,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2015-12-31 tot 2016-01-01 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2015-12-31 tot 2016-01-01' een bewoner met de volgende gegevens
@@ -353,6 +368,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op elke peild
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-09-01 tot 2010-09-02 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-09-01 tot 2010-09-02' een mogelijke bewoner met de volgende gegevens
@@ -375,6 +391,7 @@ Rule: een persoon is alleen op datum aanvang adreshouding bewoner van een adress
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-08-18 tot 2010-08-19 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-08-18 tot 2010-08-19' een bewoner met de volgende gegevens
@@ -395,6 +412,7 @@ Rule: een persoon is alleen op datum aanvang adreshouding bewoner van een adress
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-08-19 tot 2010-08-20 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-08-19 tot 2010-08-20' een mogelijke bewoner met de volgende gegevens

--- a/features/raadpleeg-bewoning-op-peildatum/geheimhouding.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/geheimhouding.feature
@@ -29,6 +29,7 @@ Rule: indicatie geheim waarde 0 wordt niet geleverd
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-09-01 tot 2010-09-02 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-09-01 tot 2010-09-02' een bewoner met de volgende gegevens
@@ -52,6 +53,7 @@ Rule: indicatie geheim waarde 0 wordt niet geleverd
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-08-18 tot 2010-08-19 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-08-18 tot 2010-08-19' een mogelijke bewoner met de volgende gegevens
@@ -77,6 +79,7 @@ Rule: indicatie geheim met waarde hoger dan 0 wordt vertaald naar geheimhoudingP
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-09-01 tot 2010-09-02 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-09-01 tot 2010-09-02' een bewoner met de volgende gegevens
@@ -110,6 +113,7 @@ Rule: indicatie geheim met waarde hoger dan 0 wordt vertaald naar geheimhoudingP
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-08-18 tot 2010-08-19 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-08-18 tot 2010-08-19' een mogelijke bewoner met de volgende gegevens

--- a/features/raadpleeg-bewoning-op-peildatum/in-onderzoek.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/in-onderzoek.feature
@@ -20,6 +20,7 @@ Rule: het in onderzoek zijn van de 'identificatiecode verblijfplaats' en/of 'dat
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2020-04-15 tot 2020-04-16 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2020-04-15 tot 2020-04-16' een bewoner met de volgende gegevens
@@ -45,6 +46,7 @@ Rule: het in onderzoek zijn van de 'identificatiecode verblijfplaats' en/of 'dat
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2020-04-15 tot 2020-04-16 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2020-04-15 tot 2020-04-16' een bewoner met de volgende gegevens
@@ -80,6 +82,7 @@ Rule: datum ingang onderzoek is niet relevant voor het wel/niet leveren van het 
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' een bewoner met de volgende gegevens
@@ -105,6 +108,7 @@ Rule: een beëindigd onderzoek wordt nooit vertaald naar indicatieVerblijfsplaat
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' een bewoner met de volgende gegevens
@@ -117,4 +121,3 @@ Rule: een beëindigd onderzoek wordt nooit vertaald naar indicatieVerblijfsplaat
     | 2020-04-01 | 2020-04-01 tot 2020-04-02 | peildatum ligt op datum ingang onderzoek                               |
     | 2020-05-01 | 2020-05-01 tot 2020-05-02 | peildatum ligt na datum ingang onderzoek en vóór datum einde onderzoek |
     | 2020-08-01 | 2020-08-01 tot 2020-08-02 | peildatum ligt na datum einde onderzoek                                |
-  

--- a/features/raadpleeg-bewoning-op-peildatum/opschorting-bijhouding.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/opschorting-bijhouding.feature
@@ -23,6 +23,7 @@ Rule: personen met een afgevoerde persoonslijst worden niet gezien als bewoner
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-09-01 tot 2010-09-02 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-09-01 tot 2010-09-02' geen bewoners
@@ -43,6 +44,7 @@ Rule: personen op een logisch verwijderde persoonslijst worden niet gezien als b
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-09-01 tot 2010-09-02 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-09-01 tot 2010-09-02' geen bewoners
@@ -63,6 +65,7 @@ Rule: personen met opschorting bijhouding met aanduiding ongelijk aan "F" of "W"
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2022-08-28 tot 2022-08-29 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2022-08-28 tot 2022-08-29' een bewoner met de volgende gegevens
@@ -91,6 +94,7 @@ Rule: personen met opschorting bijhouding met aanduiding ongelijk aan "F" of "W"
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' geen bewoners

--- a/features/raadpleeg-bewoning-op-peildatum/overzicht.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/overzicht.feature
@@ -32,6 +32,7 @@ Rule: een persoon is bewoner van een adresseerbaar object op een peildatum als:
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' een bewoner met de volgende gegevens
@@ -58,6 +59,7 @@ Rule: een persoon is bewoner van een adresseerbaar object op een peildatum als:
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' geen bewoners
@@ -84,6 +86,7 @@ Rule: een persoon is bewoner van een adresseerbaar object op een peildatum als:
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' bewoners met de volgende gegevens
@@ -112,6 +115,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' een mogelijke bewoner met de volgende gegevens
@@ -135,6 +139,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-09-01 tot 2010-09-02 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-09-01 tot 2010-09-02' een bewoner met de volgende gegevens
@@ -152,6 +157,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-07-31 tot 2010-08-01 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-07-31 tot 2010-08-01' geen bewoners
@@ -170,6 +176,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' een mogelijke bewoner met de volgende gegevens
@@ -196,6 +203,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2016-06-01 tot 2016-06-02 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2016-06-01 tot 2016-06-02' geen bewoners
@@ -214,6 +222,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2016-04-30 tot 2016-05-01 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2016-04-30 tot 2016-05-01' een bewoner met de volgende gegevens
@@ -231,6 +240,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' een mogelijke bewoner met de volgende gegevens
@@ -254,6 +264,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2011-01-01 tot 2011-01-02 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2011-01-01 tot 2011-01-02' een bewoner met de volgende gegevens
@@ -271,6 +282,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2009-12-31 tot 2010-01-01 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2009-12-31 tot 2010-01-01' geen bewoners
@@ -289,6 +301,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde           |
+    | type                             | Bewoning         |
     | periode                          | <periode>        |
     | adresseerbaarObjectIdentificatie | 0518010000713450 |
     En heeft de bewoning voor de bewoningPeriode '<periode>' een mogelijke bewoner met de volgende gegevens
@@ -315,6 +328,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2017-01-01 tot 2017-01-02 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2017-01-01 tot 2017-01-02' geen bewoners
@@ -333,6 +347,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op een peilda
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2015-12-31 tot 2016-01-01 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2015-12-31 tot 2016-01-01' een bewoner met de volgende gegevens
@@ -352,6 +367,7 @@ Rule: een persoon is mogelijk bewoner van een adresseerbaar object op elke peild
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-09-01 tot 2010-09-02 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-09-01 tot 2010-09-02' een mogelijke bewoner met de volgende gegevens
@@ -374,6 +390,7 @@ Rule: een persoon is alleen op datum aanvang adreshouding bewoner van een adress
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-08-18 tot 2010-08-19 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-08-18 tot 2010-08-19' een bewoner met de volgende gegevens
@@ -394,6 +411,7 @@ Rule: een persoon is alleen op datum aanvang adreshouding bewoner van een adress
     | adresseerbaarObjectIdentificatie | 0518010000713450     |
     Dan heeft de response een bewoning met de volgende gegevens
     | naam                             | waarde                    |
+    | type                             | Bewoning                  |
     | periode                          | 2010-08-19 tot 2010-08-20 |
     | adresseerbaarObjectIdentificatie | 0518010000713450          |
     En heeft de bewoning voor de bewoningPeriode '2010-08-19 tot 2010-08-20' een mogelijke bewoner met de volgende gegevens

--- a/specificatie/bewoning.yaml
+++ b/specificatie/bewoning.yaml
@@ -6,30 +6,76 @@ info:
 paths: {}
 components:
   schemas:
-    Bewoning:
+    AbstractBewoning:
       type: object
-      description: Bewoning van een adresseerbaar object
+      required:
+        - type
+      discriminator:
+        propertyName: type
+        mapping:
+          Bewoning: '#/components/schemas/Bewoning'
+          BewoningOnbekend: '#/components/schemas/BewoningOnbekend'
       properties:
-        adresseerbaarObjectIdentificatie:
-          $ref: 'verblijfplaats.yaml#/components/schemas/AdresseerbaarObjectIdentificatie'
-        bewoningPeriodes:
-          type: array
-          items:
-            $ref: '#/components/schemas/BewoningPeriode'
+        type:
+          type: string
+        periode:
+          $ref: '#/components/schemas/Periode'
+    Bewoning:
+      description: Bewoning van een adresseerbaar object
+      allOf:
+        - $ref: '#/components/schemas/AbstractBewoning'
+        - type: object
+          properties:
+            adresseerbaarObjectIdentificatie:
+              $ref: 'verblijfplaats.yaml#/components/schemas/AdresseerbaarObjectIdentificatie'
+            bewoningPeriodes:
+              type: array
+              items:
+                $ref: '#/components/schemas/BewoningPeriode'
+    BewoningOnbekend:
+      description: |
+        Verblijfobject waarvoor geen bewoning kan worden bepaald.
+      allOf:
+        - $ref: '#/components/schemas/AbstractBewoning'
+        - type: object
+          properties:
+            redenOnbekend:
+              $ref: 'common.yaml#/components/schemas/Waardetabel'
+    GbaAbstractBewoning:
+      type: object
+      required:
+        - type
+      discriminator:
+        propertyName: type
+        mapping:
+          Bewoning: '#/components/schemas/GbaBewoning'
+          BewoningOnbekend: '#/components/schemas/GbaBewoningOnbekend'
+      properties:
+        type:
+          type: string
         periode:
           $ref: '#/components/schemas/Periode'
     GbaBewoning:
-      type: object
       description: Bewoning van een adresseerbaar object
-      properties:
-        adresseerbaarObjectIdentificatie:
-          $ref: 'verblijfplaats.yaml#/components/schemas/AdresseerbaarObjectIdentificatie'
-        bewoningPeriodes:
-          type: array
-          items:
-            $ref: '#/components/schemas/GbaBewoningPeriode'
-        periode:
-          $ref: '#/components/schemas/Periode'
+      allOf:
+        - $ref: '#/components/schemas/GbaAbstractBewoning'
+        - type: object
+          properties:
+            adresseerbaarObjectIdentificatie:
+              $ref: 'verblijfplaats.yaml#/components/schemas/AdresseerbaarObjectIdentificatie'
+            bewoningPeriodes:
+              type: array
+              items:
+                $ref: '#/components/schemas/GbaBewoningPeriode'
+    GbaBewoningOnbekend:
+      description: |
+        Verblijfobject waarvoor geen bewoning kan worden bepaald.
+      allOf:
+        - $ref: '#/components/schemas/GbaAbstractBewoning'
+        - type: object
+          properties:
+            redenOnbekend:
+              $ref: 'common.yaml#/components/schemas/Waardetabel'
     Periode:
       type: object
       properties:
@@ -49,7 +95,7 @@ components:
           $ref: '#/components/schemas/Periode'
         bewoners:
           type: array
-          minItems: 1
+          minItems: 0
           maxItems: 100
           items:
             $ref: 'bewoner.yaml#/components/schemas/Bewoner'
@@ -57,7 +103,7 @@ components:
           type: array
           description: |
                 Personen waarbij de datum aanvang of de datum einde van de bewoning geheel of gedeeltelijk onbekend is, waardoor niet zeker is of ze in deze periode bewoner waren.
-          minItems: 1
+          minItems: 0
           maxItems: 100
           items:
             $ref: 'bewoner.yaml#/components/schemas/Bewoner'
@@ -72,7 +118,7 @@ components:
           $ref: '#/components/schemas/Periode'
         bewoners:
           type: array
-          minItems: 1
+          minItems: 0
           maxItems: 100
           items:
             $ref: 'bewoner.yaml#/components/schemas/GbaBewoner'
@@ -80,7 +126,7 @@ components:
           type: array
           description: |
                 Personen waarbij de datum aanvang of de datum einde van de bewoning geheel of gedeeltelijk onbekend is, waardoor niet zeker is of ze in deze periode bewoner waren.
-          minItems: 1
+          minItems: 0
           maxItems: 100
           items:
             $ref: 'bewoner.yaml#/components/schemas/GbaBewoner'

--- a/specificatie/bewoning.yaml
+++ b/specificatie/bewoning.yaml
@@ -37,10 +37,6 @@ components:
         Verblijfobject waarvoor geen bewoning kan worden bepaald.
       allOf:
         - $ref: '#/components/schemas/AbstractBewoning'
-        - type: object
-          properties:
-            redenOnbekend:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
     GbaAbstractBewoning:
       type: object
       required:
@@ -72,10 +68,6 @@ components:
         Verblijfobject waarvoor geen bewoning kan worden bepaald.
       allOf:
         - $ref: '#/components/schemas/GbaAbstractBewoning'
-        - type: object
-          properties:
-            redenOnbekend:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
     Periode:
       type: object
       properties:

--- a/specificatie/gba-genereervariant/openapi.json
+++ b/specificatie/gba-genereervariant/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi" : "3.0.3",
   "info" : {
-    "title" : "BRP bewoning",
+    "title" : "Haal Centraal BRP bewoning",
     "description" : "API voor het raadplegen van de (historische) bewoning van een adres.\n",
     "contact" : {
       "url" : "https://github.com/BRP-API/Haal-Centraal-BRP-bewoning"
@@ -13,7 +13,11 @@
     "version" : "2.0.0"
   },
   "servers" : [ {
-    "url" : "/"
+    "url" : "https://proefomgeving.haalcentraal.nl/haalcentraal/api/bewoning",
+    "description" : "Proef omgeving\n"
+  }, {
+    "url" : "http://localhost:5010/haalcentraal/api/bewoning",
+    "description" : "Lokaal\n"
   } ],
   "tags" : [ {
     "name" : "Bewoning"
@@ -330,7 +334,7 @@
           "bewoningen" : {
             "type" : "array",
             "items" : {
-              "$ref" : "#/components/schemas/GbaBewoning"
+              "$ref" : "#/components/schemas/GbaAbstractBewoning"
             }
           }
         }
@@ -443,53 +447,24 @@
         "format" : "date",
         "example" : "1964-09-24"
       },
-      "GbaBewoning" : {
+      "GbaAbstractBewoning" : {
+        "required" : [ "type" ],
         "type" : "object",
         "properties" : {
-          "adresseerbaarObjectIdentificatie" : {
-            "$ref" : "#/components/schemas/AdresseerbaarObjectIdentificatie"
-          },
-          "bewoningPeriodes" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/GbaBewoningPeriode"
-            }
+          "type" : {
+            "type" : "string"
           },
           "periode" : {
             "$ref" : "#/components/schemas/Periode"
           }
         },
-        "description" : "Bewoning van een adresseerbaar object"
-      },
-      "GbaBewoningPeriode" : {
-        "type" : "object",
-        "properties" : {
-          "periode" : {
-            "$ref" : "#/components/schemas/Periode"
-          },
-          "bewoners" : {
-            "maxItems" : 100,
-            "minItems" : 1,
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/GbaBewoner"
-            }
-          },
-          "mogelijkeBewoners" : {
-            "maxItems" : 100,
-            "minItems" : 1,
-            "type" : "array",
-            "description" : "Personen waarbij de datum aanvang of de datum einde van de bewoning geheel of gedeeltelijk onbekend is, waardoor niet zeker is of ze in deze periode bewoner waren.\n",
-            "items" : {
-              "$ref" : "#/components/schemas/GbaBewoner"
-            }
-          },
-          "indicatieVeelBewoners" : {
-            "type" : "boolean",
-            "description" : "Geeft aan dat het adresseerbaar object zo veel bewoners heeft of had in de gevraagde periode dat zij niet in het antwoord worden opgenomen, met uitzondering van de persoon waarvan de BSN is opgegeven."
+        "discriminator" : {
+          "propertyName" : "type",
+          "mapping" : {
+            "Bewoning" : "#/components/schemas/GbaBewoning",
+            "BewoningOnbekend" : "#/components/schemas/GbaBewoningOnbekend"
           }
-        },
-        "description" : "Tijdsperiode waarin op het adresseerbaar object een bepaalde samenstelling van bewoners was."
+        }
       },
       "Periode" : {
         "type" : "object",
@@ -505,6 +480,68 @@
             "example" : "2021-01-01"
           }
         }
+      },
+      "GbaBewoning" : {
+        "description" : "Bewoning van een adresseerbaar object",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/GbaAbstractBewoning"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "adresseerbaarObjectIdentificatie" : {
+              "$ref" : "#/components/schemas/AdresseerbaarObjectIdentificatie"
+            },
+            "bewoningPeriodes" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/GbaBewoningPeriode"
+              }
+            }
+          }
+        } ]
+      },
+      "GbaBewoningPeriode" : {
+        "type" : "object",
+        "properties" : {
+          "periode" : {
+            "$ref" : "#/components/schemas/Periode"
+          },
+          "bewoners" : {
+            "maxItems" : 100,
+            "minItems" : 0,
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/GbaBewoner"
+            }
+          },
+          "mogelijkeBewoners" : {
+            "maxItems" : 100,
+            "minItems" : 0,
+            "type" : "array",
+            "description" : "Personen waarbij de datum aanvang of de datum einde van de bewoning geheel of gedeeltelijk onbekend is, waardoor niet zeker is of ze in deze periode bewoner waren.\n",
+            "items" : {
+              "$ref" : "#/components/schemas/GbaBewoner"
+            }
+          },
+          "indicatieVeelBewoners" : {
+            "type" : "boolean",
+            "description" : "Geeft aan dat het adresseerbaar object zo veel bewoners heeft of had in de gevraagde periode dat zij niet in het antwoord worden opgenomen, met uitzondering van de persoon waarvan de BSN is opgegeven."
+          }
+        },
+        "description" : "Tijdsperiode waarin op het adresseerbaar object een bepaalde samenstelling van bewoners was."
+      },
+      "GbaBewoningOnbekend" : {
+        "description" : "Verblijfobject waarvoor geen bewoning kan worden bepaald.\n",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/GbaAbstractBewoning"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "redenOnbekend" : {
+              "$ref" : "#/components/schemas/Waardetabel"
+            }
+          }
+        } ]
       },
       "GbaBewoner" : {
         "type" : "object",
@@ -529,6 +566,21 @@
         "maximum" : 7,
         "minimum" : 0,
         "type" : "integer"
+      },
+      "Waardetabel" : {
+        "type" : "object",
+        "properties" : {
+          "code" : {
+            "pattern" : "^[a-zA-Z0-9 \\.]+$",
+            "type" : "string",
+            "example" : "6030"
+          },
+          "omschrijving" : {
+            "pattern" : "^[a-zA-Z0-9À-ž \\'\\,\\(\\)\\.\\-]{1,200}$",
+            "type" : "string",
+            "example" : "Nederland"
+          }
+        }
       },
       "GbaInOnderzoek" : {
         "pattern" : "^[0-9]{6}$",

--- a/specificatie/gba-genereervariant/openapi.json
+++ b/specificatie/gba-genereervariant/openapi.json
@@ -534,13 +534,6 @@
         "description" : "Verblijfobject waarvoor geen bewoning kan worden bepaald.\n",
         "allOf" : [ {
           "$ref" : "#/components/schemas/GbaAbstractBewoning"
-        }, {
-          "type" : "object",
-          "properties" : {
-            "redenOnbekend" : {
-              "$ref" : "#/components/schemas/Waardetabel"
-            }
-          }
         } ]
       },
       "GbaBewoner" : {
@@ -566,21 +559,6 @@
         "maximum" : 7,
         "minimum" : 0,
         "type" : "integer"
-      },
-      "Waardetabel" : {
-        "type" : "object",
-        "properties" : {
-          "code" : {
-            "pattern" : "^[a-zA-Z0-9 \\.]+$",
-            "type" : "string",
-            "example" : "6030"
-          },
-          "omschrijving" : {
-            "pattern" : "^[a-zA-Z0-9À-ž \\'\\,\\(\\)\\.\\-]{1,200}$",
-            "type" : "string",
-            "example" : "Nederland"
-          }
-        }
       },
       "GbaInOnderzoek" : {
         "pattern" : "^[0-9]{6}$",

--- a/specificatie/gba-genereervariant/openapi.yaml
+++ b/specificatie/gba-genereervariant/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: BRP bewoning
+  title: Haal Centraal BRP bewoning
   description: |
     API voor het raadplegen van de (historische) bewoning van een adres.
   contact:
@@ -10,7 +10,12 @@ info:
     url: https://eupl.eu/1.2/nl/
   version: 2.0.0
 servers:
-- url: /
+- url: https://proefomgeving.haalcentraal.nl/haalcentraal/api/bewoning
+  description: |
+    Proef omgeving
+- url: http://localhost:5010/haalcentraal/api/bewoning
+  description: |
+    Lokaal
 tags:
 - name: Bewoning
 paths:
@@ -249,7 +254,7 @@ components:
         bewoningen:
           type: array
           items:
-            $ref: '#/components/schemas/GbaBewoning'
+            $ref: '#/components/schemas/GbaAbstractBewoning'
     BadRequestFoutbericht:
       allOf:
       - $ref: '#/components/schemas/Foutbericht'
@@ -339,18 +344,43 @@ components:
         De einddatum van de periode waarover de bewoning wordt opgevraagd.
       format: date
       example: 1964-09-24
-    GbaBewoning:
+    GbaAbstractBewoning:
+      required:
+      - type
       type: object
       properties:
-        adresseerbaarObjectIdentificatie:
-          $ref: '#/components/schemas/AdresseerbaarObjectIdentificatie'
-        bewoningPeriodes:
-          type: array
-          items:
-            $ref: '#/components/schemas/GbaBewoningPeriode'
+        type:
+          type: string
         periode:
           $ref: '#/components/schemas/Periode'
+      discriminator:
+        propertyName: type
+        mapping:
+          Bewoning: '#/components/schemas/GbaBewoning'
+          BewoningOnbekend: '#/components/schemas/GbaBewoningOnbekend'
+    Periode:
+      type: object
+      properties:
+        datumVan:
+          type: string
+          format: date
+          example: 2020-01-01
+        datumTot:
+          type: string
+          format: date
+          example: 2021-01-01
+    GbaBewoning:
       description: Bewoning van een adresseerbaar object
+      allOf:
+      - $ref: '#/components/schemas/GbaAbstractBewoning'
+      - type: object
+        properties:
+          adresseerbaarObjectIdentificatie:
+            $ref: '#/components/schemas/AdresseerbaarObjectIdentificatie'
+          bewoningPeriodes:
+            type: array
+            items:
+              $ref: '#/components/schemas/GbaBewoningPeriode'
     GbaBewoningPeriode:
       type: object
       properties:
@@ -358,13 +388,13 @@ components:
           $ref: '#/components/schemas/Periode'
         bewoners:
           maxItems: 100
-          minItems: 1
+          minItems: 0
           type: array
           items:
             $ref: '#/components/schemas/GbaBewoner'
         mogelijkeBewoners:
           maxItems: 100
-          minItems: 1
+          minItems: 0
           type: array
           description: |
             Personen waarbij de datum aanvang of de datum einde van de bewoning geheel of gedeeltelijk onbekend is, waardoor niet zeker is of ze in deze periode bewoner waren.
@@ -377,17 +407,15 @@ components:
             \ met uitzondering van de persoon waarvan de BSN is opgegeven."
       description: Tijdsperiode waarin op het adresseerbaar object een bepaalde samenstelling
         van bewoners was.
-    Periode:
-      type: object
-      properties:
-        datumVan:
-          type: string
-          format: date
-          example: 2020-01-01
-        datumTot:
-          type: string
-          format: date
-          example: 2021-01-01
+    GbaBewoningOnbekend:
+      description: |
+        Verblijfobject waarvoor geen bewoning kan worden bepaald.
+      allOf:
+      - $ref: '#/components/schemas/GbaAbstractBewoning'
+      - type: object
+        properties:
+          redenOnbekend:
+            $ref: '#/components/schemas/Waardetabel'
     GbaBewoner:
       type: object
       properties:
@@ -405,6 +433,17 @@ components:
       maximum: 7
       minimum: 0
       type: integer
+    Waardetabel:
+      type: object
+      properties:
+        code:
+          pattern: "^[a-zA-Z0-9 \\.]+$"
+          type: string
+          example: "6030"
+        omschrijving:
+          pattern: "^[a-zA-Z0-9À-ž \\'\\,\\(\\)\\.\\-]{1,200}$"
+          type: string
+          example: Nederland
     GbaInOnderzoek:
       pattern: "^[0-9]{6}$"
       type: string

--- a/specificatie/gba-genereervariant/openapi.yaml
+++ b/specificatie/gba-genereervariant/openapi.yaml
@@ -412,10 +412,6 @@ components:
         Verblijfobject waarvoor geen bewoning kan worden bepaald.
       allOf:
       - $ref: '#/components/schemas/GbaAbstractBewoning'
-      - type: object
-        properties:
-          redenOnbekend:
-            $ref: '#/components/schemas/Waardetabel'
     GbaBewoner:
       type: object
       properties:
@@ -433,17 +429,6 @@ components:
       maximum: 7
       minimum: 0
       type: integer
-    Waardetabel:
-      type: object
-      properties:
-        code:
-          pattern: "^[a-zA-Z0-9 \\.]+$"
-          type: string
-          example: "6030"
-        omschrijving:
-          pattern: "^[a-zA-Z0-9À-ž \\'\\,\\(\\)\\.\\-]{1,200}$"
-          type: string
-          example: Nederland
     GbaInOnderzoek:
       pattern: "^[0-9]{6}$"
       type: string

--- a/specificatie/gba-openapi.yaml
+++ b/specificatie/gba-openapi.yaml
@@ -1,6 +1,13 @@
 openapi: 3.0.3
+servers:
+  - description: |
+      Proef omgeving
+    url: https://proefomgeving.haalcentraal.nl/haalcentraal/api/bewoning
+  - description: |
+      Lokaal
+    url: http://localhost:5010/haalcentraal/api/bewoning
 info:
-  title: BRP bewoning
+  title: Haal Centraal BRP bewoning
   description: |
     API voor het raadplegen van de (historische) bewoning van een adres.
   version: 2.0.0
@@ -113,4 +120,4 @@ components:
         bewoningen:
           type: array
           items:
-            $ref: 'bewoning.yaml#/components/schemas/GbaBewoning'
+            $ref: 'bewoning.yaml#/components/schemas/GbaAbstractBewoning'

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -531,13 +531,6 @@
         "description" : "Verblijfobject waarvoor geen bewoning kan worden bepaald.\n",
         "allOf" : [ {
           "$ref" : "#/components/schemas/AbstractBewoning"
-        }, {
-          "type" : "object",
-          "properties" : {
-            "redenOnbekend" : {
-              "$ref" : "#/components/schemas/Waardetabel"
-            }
-          }
         } ]
       },
       "Bewoner" : {
@@ -562,21 +555,6 @@
       "GeheimhoudingPersoonsgegevens" : {
         "type" : "boolean",
         "description" : "Gegevens mogen niet worden verstrekt aan derden / maatschappelijke instellingen.\n"
-      },
-      "Waardetabel" : {
-        "type" : "object",
-        "properties" : {
-          "code" : {
-            "pattern" : "^[a-zA-Z0-9 \\.]+$",
-            "type" : "string",
-            "example" : "6030"
-          },
-          "omschrijving" : {
-            "pattern" : "^[a-zA-Z0-9À-ž \\'\\,\\(\\)\\.\\-]{1,200}$",
-            "type" : "string",
-            "example" : "Nederland"
-          }
-        }
       },
       "InOnderzoek" : {
         "type" : "boolean",

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -331,7 +331,7 @@
           "bewoningen" : {
             "type" : "array",
             "items" : {
-              "$ref" : "#/components/schemas/Bewoning"
+              "$ref" : "#/components/schemas/AbstractBewoning"
             }
           }
         }
@@ -444,53 +444,24 @@
         "format" : "date",
         "example" : "1964-09-24"
       },
-      "Bewoning" : {
+      "AbstractBewoning" : {
+        "required" : [ "type" ],
         "type" : "object",
         "properties" : {
-          "adresseerbaarObjectIdentificatie" : {
-            "$ref" : "#/components/schemas/AdresseerbaarObjectIdentificatie"
-          },
-          "bewoningPeriodes" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/BewoningPeriode"
-            }
+          "type" : {
+            "type" : "string"
           },
           "periode" : {
             "$ref" : "#/components/schemas/Periode"
           }
         },
-        "description" : "Bewoning van een adresseerbaar object"
-      },
-      "BewoningPeriode" : {
-        "type" : "object",
-        "properties" : {
-          "periode" : {
-            "$ref" : "#/components/schemas/Periode"
-          },
-          "bewoners" : {
-            "maxItems" : 100,
-            "minItems" : 1,
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/Bewoner"
-            }
-          },
-          "mogelijkeBewoners" : {
-            "maxItems" : 100,
-            "minItems" : 1,
-            "type" : "array",
-            "description" : "Personen waarbij de datum aanvang of de datum einde van de bewoning geheel of gedeeltelijk onbekend is, waardoor niet zeker is of ze in deze periode bewoner waren.\n",
-            "items" : {
-              "$ref" : "#/components/schemas/Bewoner"
-            }
-          },
-          "indicatieVeelBewoners" : {
-            "type" : "boolean",
-            "description" : "Geeft aan dat het adresseerbaar object zo veel bewoners heeft of had in de gevraagde periode dat zij niet in het antwoord worden opgenomen, met uitzondering van de persoon waarvan de BSN is opgegeven."
+        "discriminator" : {
+          "propertyName" : "type",
+          "mapping" : {
+            "Bewoning" : "#/components/schemas/Bewoning",
+            "BewoningOnbekend" : "#/components/schemas/BewoningOnbekend"
           }
-        },
-        "description" : "Tijdsperiode waarin op het adresseerbaar object een bepaalde samenstelling van bewoners was."
+        }
       },
       "Periode" : {
         "type" : "object",
@@ -506,6 +477,68 @@
             "example" : "2021-01-01"
           }
         }
+      },
+      "Bewoning" : {
+        "description" : "Bewoning van een adresseerbaar object",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/AbstractBewoning"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "adresseerbaarObjectIdentificatie" : {
+              "$ref" : "#/components/schemas/AdresseerbaarObjectIdentificatie"
+            },
+            "bewoningPeriodes" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/BewoningPeriode"
+              }
+            }
+          }
+        } ]
+      },
+      "BewoningPeriode" : {
+        "type" : "object",
+        "properties" : {
+          "periode" : {
+            "$ref" : "#/components/schemas/Periode"
+          },
+          "bewoners" : {
+            "maxItems" : 100,
+            "minItems" : 0,
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Bewoner"
+            }
+          },
+          "mogelijkeBewoners" : {
+            "maxItems" : 100,
+            "minItems" : 0,
+            "type" : "array",
+            "description" : "Personen waarbij de datum aanvang of de datum einde van de bewoning geheel of gedeeltelijk onbekend is, waardoor niet zeker is of ze in deze periode bewoner waren.\n",
+            "items" : {
+              "$ref" : "#/components/schemas/Bewoner"
+            }
+          },
+          "indicatieVeelBewoners" : {
+            "type" : "boolean",
+            "description" : "Geeft aan dat het adresseerbaar object zo veel bewoners heeft of had in de gevraagde periode dat zij niet in het antwoord worden opgenomen, met uitzondering van de persoon waarvan de BSN is opgegeven."
+          }
+        },
+        "description" : "Tijdsperiode waarin op het adresseerbaar object een bepaalde samenstelling van bewoners was."
+      },
+      "BewoningOnbekend" : {
+        "description" : "Verblijfobject waarvoor geen bewoning kan worden bepaald.\n",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/AbstractBewoning"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "redenOnbekend" : {
+              "$ref" : "#/components/schemas/Waardetabel"
+            }
+          }
+        } ]
       },
       "Bewoner" : {
         "type" : "object",
@@ -529,6 +562,21 @@
       "GeheimhoudingPersoonsgegevens" : {
         "type" : "boolean",
         "description" : "Gegevens mogen niet worden verstrekt aan derden / maatschappelijke instellingen.\n"
+      },
+      "Waardetabel" : {
+        "type" : "object",
+        "properties" : {
+          "code" : {
+            "pattern" : "^[a-zA-Z0-9 \\.]+$",
+            "type" : "string",
+            "example" : "6030"
+          },
+          "omschrijving" : {
+            "pattern" : "^[a-zA-Z0-9À-ž \\'\\,\\(\\)\\.\\-]{1,200}$",
+            "type" : "string",
+            "example" : "Nederland"
+          }
+        }
       },
       "InOnderzoek" : {
         "type" : "boolean",

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -408,10 +408,6 @@ components:
         Verblijfobject waarvoor geen bewoning kan worden bepaald.
       allOf:
       - $ref: '#/components/schemas/AbstractBewoning'
-      - type: object
-        properties:
-          redenOnbekend:
-            $ref: '#/components/schemas/Waardetabel'
     Bewoner:
       type: object
       properties:
@@ -429,17 +425,6 @@ components:
       type: boolean
       description: |
         Gegevens mogen niet worden verstrekt aan derden / maatschappelijke instellingen.
-    Waardetabel:
-      type: object
-      properties:
-        code:
-          pattern: "^[a-zA-Z0-9 \\.]+$"
-          type: string
-          example: "6030"
-        omschrijving:
-          pattern: "^[a-zA-Z0-9À-ž \\'\\,\\(\\)\\.\\-]{1,200}$"
-          type: string
-          example: Nederland
     InOnderzoek:
       type: boolean
       description: |

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -250,7 +250,7 @@ components:
         bewoningen:
           type: array
           items:
-            $ref: '#/components/schemas/Bewoning'
+            $ref: '#/components/schemas/AbstractBewoning'
     BadRequestFoutbericht:
       allOf:
       - $ref: '#/components/schemas/Foutbericht'
@@ -340,18 +340,43 @@ components:
         De einddatum van de periode waarover de bewoning wordt opgevraagd.
       format: date
       example: 1964-09-24
-    Bewoning:
+    AbstractBewoning:
+      required:
+      - type
       type: object
       properties:
-        adresseerbaarObjectIdentificatie:
-          $ref: '#/components/schemas/AdresseerbaarObjectIdentificatie'
-        bewoningPeriodes:
-          type: array
-          items:
-            $ref: '#/components/schemas/BewoningPeriode'
+        type:
+          type: string
         periode:
           $ref: '#/components/schemas/Periode'
+      discriminator:
+        propertyName: type
+        mapping:
+          Bewoning: '#/components/schemas/Bewoning'
+          BewoningOnbekend: '#/components/schemas/BewoningOnbekend'
+    Periode:
+      type: object
+      properties:
+        datumVan:
+          type: string
+          format: date
+          example: 2020-01-01
+        datumTot:
+          type: string
+          format: date
+          example: 2021-01-01
+    Bewoning:
       description: Bewoning van een adresseerbaar object
+      allOf:
+      - $ref: '#/components/schemas/AbstractBewoning'
+      - type: object
+        properties:
+          adresseerbaarObjectIdentificatie:
+            $ref: '#/components/schemas/AdresseerbaarObjectIdentificatie'
+          bewoningPeriodes:
+            type: array
+            items:
+              $ref: '#/components/schemas/BewoningPeriode'
     BewoningPeriode:
       type: object
       properties:
@@ -359,13 +384,13 @@ components:
           $ref: '#/components/schemas/Periode'
         bewoners:
           maxItems: 100
-          minItems: 1
+          minItems: 0
           type: array
           items:
             $ref: '#/components/schemas/Bewoner'
         mogelijkeBewoners:
           maxItems: 100
-          minItems: 1
+          minItems: 0
           type: array
           description: |
             Personen waarbij de datum aanvang of de datum einde van de bewoning geheel of gedeeltelijk onbekend is, waardoor niet zeker is of ze in deze periode bewoner waren.
@@ -378,17 +403,15 @@ components:
             \ met uitzondering van de persoon waarvan de BSN is opgegeven."
       description: Tijdsperiode waarin op het adresseerbaar object een bepaalde samenstelling
         van bewoners was.
-    Periode:
-      type: object
-      properties:
-        datumVan:
-          type: string
-          format: date
-          example: 2020-01-01
-        datumTot:
-          type: string
-          format: date
-          example: 2021-01-01
+    BewoningOnbekend:
+      description: |
+        Verblijfobject waarvoor geen bewoning kan worden bepaald.
+      allOf:
+      - $ref: '#/components/schemas/AbstractBewoning'
+      - type: object
+        properties:
+          redenOnbekend:
+            $ref: '#/components/schemas/Waardetabel'
     Bewoner:
       type: object
       properties:
@@ -406,6 +429,17 @@ components:
       type: boolean
       description: |
         Gegevens mogen niet worden verstrekt aan derden / maatschappelijke instellingen.
+    Waardetabel:
+      type: object
+      properties:
+        code:
+          pattern: "^[a-zA-Z0-9 \\.]+$"
+          type: string
+          example: "6030"
+        omschrijving:
+          pattern: "^[a-zA-Z0-9À-ž \\'\\,\\(\\)\\.\\-]{1,200}$"
+          type: string
+          example: Nederland
     InOnderzoek:
       type: boolean
       description: |

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -114,4 +114,4 @@ components:
         bewoningen:
           type: array
           items:
-            $ref: 'bewoning.yaml#/components/schemas/Bewoning'
+            $ref: 'bewoning.yaml#/components/schemas/AbstractBewoning'


### PR DESCRIPTION
OAS wijzigingen:
- [x] (Gba)AbstractBewoning schema type toegevoegd
- [x] (Gba)BewoningOnbekend schema type toegevoegd
- [x] minItems aangepast naar 0 van mogelijkeBewoners en bewoners properties in (Gba)BewoningPeriode. Een bewoning periode kan geen mogelijke bewoners en/of bewoners hebben
- [x] servers property is toegevoegd aan gba-openapi.yaml tbv code generatie

Features wijzigingen:
- [x] type = bewoning toegevoegd aan de response beschrijving in de proxy en gba scenarios

closes #154 