### PR TITLE
autorisatiescenario's in geval van gemeentelijke herindeling

### DIFF
--- a/features/raadpleeg-bewoning-op-peildatum/gba/autorisatie-gba.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/gba/autorisatie-gba.feature
@@ -106,3 +106,135 @@ Functionaliteit: autorisatie voor het gebruik van de API BewoningMetPeildatum
       | detail   | Je mag alleen bewoning van adresseerbare objecten binnen de eigen gemeente raadplegen. |
       | code     | unauthorized                                                                           |
       | instance | /haalcentraal/api/bewoning/bewoningen                                                  |
+
+  Rule: Een gemeente als afnemer is geautoriseerd voor het bevragen van bewoning van een adresseerbaar object dat is overgegaan van een andere gemeente vanaf het moment van overgaan
+
+    Scenario: Adres is na gemeentelijke herindeling in vragende gemeente komen te liggen en bewoning wordt gevraagd na de herindeling
+      Gegeven adres 'A3' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+      | 0530                 | 0530010000000003                         |
+      En adres 'A4' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+      | 0800                 | 0530010000000003                         |
+      En de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A3' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0530                              | 20100818                           |
+      En de persoon is vervolgens ingeschreven op adres 'A4' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20230526                           |
+      Als gba bewoning wordt gezocht met de volgende parameters
+      | naam                             | waarde               |
+      | type                             | BewoningMetPeildatum |
+      | peildatum                        | 2023-07-01           |
+      | adresseerbaarObjectIdentificatie | 0530010000000003     |
+      Dan heeft de response 1 bewoning
+
+    @fout-case
+    Scenario: Adres is na gemeentelijke herindeling in vragende gemeente komen te liggen en bewoning wordt gevraagd voor de herindeling
+      Gegeven adres 'A3' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+      | 0530                 | 0530010000000003                         |
+      En adres 'A4' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+      | 0800                 | 0530010000000003                         |
+      En de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A3' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0530                              | 20100818                           |
+      En de persoon is vervolgens ingeschreven op adres 'A4' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20230526                           |
+      Als gba bewoning wordt gezocht met de volgende parameters
+      | naam                             | waarde               |
+      | type                             | BewoningMetPeildatum |
+      | peildatum                        | 2023-01-01           |
+      | adresseerbaarObjectIdentificatie | 0530010000000003     |
+      Dan heeft de response een object met de volgende gegevens
+      | naam     | waarde                                                                                 |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                            |
+      | title    | U bent niet geautoriseerd voor deze vraag.                                             |
+      | status   | 403                                                                                    |
+      | detail   | Je mag alleen bewoning van adresseerbare objecten binnen de eigen gemeente raadplegen. |
+      | code     | unauthorized                                                                           |
+      | instance | /haalcentraal/api/bewoning/bewoningen                                                  |
+
+    Scenario: Adres is na gemeentelijke herindeling in andere gemeente komen te liggen en bewoning wordt gevraagd voor de herindeling
+      Gegeven adres 'A3' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+      | 0800                 | 0800010000000003                         |
+      En adres 'A4' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+      | 0530                 | 0800010000000003                         |
+      En de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A3' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20100818                           |
+      En de persoon is vervolgens ingeschreven op adres 'A4' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0530                              | 20230526                           |
+      Als gba bewoning wordt gezocht met de volgende parameters
+      | naam                             | waarde               |
+      | type                             | BewoningMetPeildatum |
+      | peildatum                        | 2023-01-01           |
+      | adresseerbaarObjectIdentificatie | 0800010000000003     |
+      Dan heeft de response 1 bewoning
+
+    @fout-case
+    Scenario: Adres is na gemeentelijke herindeling in andere gemeente komen te liggen en bewoning wordt gevraagd na de herindeling
+      Gegeven adres 'A3' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+      | 0800                 | 0800010000000003                         |
+      En adres 'A4' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+      | 0530                 | 0800010000000003                         |
+      En de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A3' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20100818                           |
+      En de persoon is vervolgens ingeschreven op adres 'A4' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0530                              | 20230526                           |
+      Als gba bewoning wordt gezocht met de volgende parameters
+      | naam                             | waarde               |
+      | type                             | BewoningMetPeildatum |
+      | peildatum                        | 2023-07-01           |
+      | adresseerbaarObjectIdentificatie | 0800010000000003     |
+      Dan heeft de response een object met de volgende gegevens
+      | naam     | waarde                                                                                 |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                            |
+      | title    | U bent niet geautoriseerd voor deze vraag.                                             |
+      | status   | 403                                                                                    |
+      | detail   | Je mag alleen bewoning van adresseerbare objecten binnen de eigen gemeente raadplegen. |
+      | code     | unauthorized                                                                           |
+      | instance | /haalcentraal/api/bewoning/bewoningen                                                  |
+
+
+  Rule: Een gemeente als afnemer is geautoriseerd voor het bevragen van bewoning van een adresseerbaar object in een gemeente die is overgegaan of samengevoegd met de afnemer gemeente
+
+    Abstract Scenario: Adres ligt in samengevoegde gemeente en <scenario>
+      Gegeven een gemeente met de volgende gegevens
+      | code | omschrijving | nieuwe code | datum einde |
+      | 9999 | Ons Dorp     | 0800        | 20230526    |
+      En een gemeente met de volgende gegevens
+      | code | omschrijving          | nieuwe code | datum einde |
+      | 0800 | Samenvoegingsgemeente | 0800        |             |
+      En adres 'A3' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+      | 9999                 | 9999010000000003                         |
+      En adres 'A4' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+      | 0800                 | 9999010000000003                         |
+      En de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A3' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 9999                              | 20100818                           |
+      En de persoon is vervolgens ingeschreven op adres 'A4' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20230526                           |
+      Als gba bewoning wordt gezocht met de volgende parameters
+      | naam                             | waarde               |
+      | type                             | BewoningMetPeildatum |
+      | peildatum                        | <peildatum>          |
+      | adresseerbaarObjectIdentificatie | 9999010000000003     |
+      Dan heeft de response 1 bewoning
+
+      Voorbeelden:
+      | peildatum  | scenario                                     |
+      | 2023-07-01 | bewoning wordt gevraagd na de samenvoeging   |
+      | 2023-01-01 | bewoning wordt gevraagd voor de samenvoeging |

--- a/features/raadpleeg-bewoning-op-peildatum/gba/autorisatie-gba.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/gba/autorisatie-gba.feature
@@ -109,19 +109,16 @@ Functionaliteit: autorisatie voor het gebruik van de API BewoningMetPeildatum
 
   Rule: Een gemeente als afnemer is geautoriseerd voor het bevragen van bewoning van een adresseerbaar object dat is overgegaan van een andere gemeente vanaf het moment van overgaan
 
-    Scenario: Adres is na gemeentelijke herindeling in vragende gemeente komen te liggen en bewoning wordt gevraagd na de herindeling
+    Scenario: Adres is na gemeentelijke herindeling in vragende gemeente komen te liggen en peildatum ligt na de herindeling
       Gegeven adres 'A3' heeft de volgende gegevens
       | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
       | 0530                 | 0530010000000003                         |
-      En adres 'A4' heeft de volgende gegevens
-      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
-      | 0800                 | 0530010000000003                         |
       En de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A3' met de volgende gegevens
       | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
       | 0530                              | 20100818                           |
-      En de persoon is vervolgens ingeschreven op adres 'A4' met de volgende gegevens
-      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
-      | 0800                              | 20230526                           |
+      En adres 'A3' is op '2023-05-26' infrastructureel gewijzigd met de volgende gegevens
+      | gemeentecode (92.10) |
+      | 0800                 |
       Als gba bewoning wordt gezocht met de volgende parameters
       | naam                             | waarde               |
       | type                             | BewoningMetPeildatum |
@@ -130,19 +127,16 @@ Functionaliteit: autorisatie voor het gebruik van de API BewoningMetPeildatum
       Dan heeft de response 1 bewoning
 
     @fout-case
-    Scenario: Adres is na gemeentelijke herindeling in vragende gemeente komen te liggen en bewoning wordt gevraagd voor de herindeling
+    Scenario: Adres is na gemeentelijke herindeling in vragende gemeente komen te liggen en peildatum ligt voor de herindeling
       Gegeven adres 'A3' heeft de volgende gegevens
       | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
       | 0530                 | 0530010000000003                         |
-      En adres 'A4' heeft de volgende gegevens
-      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
-      | 0800                 | 0530010000000003                         |
       En de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A3' met de volgende gegevens
       | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
       | 0530                              | 20100818                           |
-      En de persoon is vervolgens ingeschreven op adres 'A4' met de volgende gegevens
-      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
-      | 0800                              | 20230526                           |
+      En adres 'A3' is op '2023-05-26' infrastructureel gewijzigd met de volgende gegevens
+      | gemeentecode (92.10) |
+      | 0800                 |
       Als gba bewoning wordt gezocht met de volgende parameters
       | naam                             | waarde               |
       | type                             | BewoningMetPeildatum |
@@ -157,19 +151,16 @@ Functionaliteit: autorisatie voor het gebruik van de API BewoningMetPeildatum
       | code     | unauthorized                                                                           |
       | instance | /haalcentraal/api/bewoning/bewoningen                                                  |
 
-    Scenario: Adres is na gemeentelijke herindeling in andere gemeente komen te liggen en bewoning wordt gevraagd voor de herindeling
+    Scenario: Adres is na gemeentelijke herindeling in andere gemeente komen te liggen en peildatum ligt voor datum herindeling
       Gegeven adres 'A3' heeft de volgende gegevens
       | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
       | 0800                 | 0800010000000003                         |
-      En adres 'A4' heeft de volgende gegevens
-      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
-      | 0530                 | 0800010000000003                         |
       En de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A3' met de volgende gegevens
       | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
       | 0800                              | 20100818                           |
-      En de persoon is vervolgens ingeschreven op adres 'A4' met de volgende gegevens
-      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
-      | 0530                              | 20230526                           |
+      En adres 'A3' is op '2023-05-26' infrastructureel gewijzigd met de volgende gegevens
+      | gemeentecode (92.10) |
+      | 0530                 |
       Als gba bewoning wordt gezocht met de volgende parameters
       | naam                             | waarde               |
       | type                             | BewoningMetPeildatum |
@@ -178,19 +169,16 @@ Functionaliteit: autorisatie voor het gebruik van de API BewoningMetPeildatum
       Dan heeft de response 1 bewoning
 
     @fout-case
-    Scenario: Adres is na gemeentelijke herindeling in andere gemeente komen te liggen en bewoning wordt gevraagd na de herindeling
+    Scenario: Adres is na gemeentelijke herindeling in andere gemeente komen te liggen en peildatum ligt na datum herindeling
       Gegeven adres 'A3' heeft de volgende gegevens
       | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
       | 0800                 | 0800010000000003                         |
-      En adres 'A4' heeft de volgende gegevens
-      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
-      | 0530                 | 0800010000000003                         |
       En de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A3' met de volgende gegevens
       | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
       | 0800                              | 20100818                           |
-      En de persoon is vervolgens ingeschreven op adres 'A4' met de volgende gegevens
-      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
-      | 0530                              | 20230526                           |
+      En adres 'A3' is op '2023-05-26' infrastructureel gewijzigd met de volgende gegevens
+      | gemeentecode (92.10) |
+      | 0530                 |
       Als gba bewoning wordt gezocht met de volgende parameters
       | naam                             | waarde               |
       | type                             | BewoningMetPeildatum |
@@ -210,20 +198,17 @@ Functionaliteit: autorisatie voor het gebruik van de API BewoningMetPeildatum
 
     Abstract Scenario: Adres ligt in samengevoegde gemeente en <scenario>
       Gegeven een gemeente met de volgende gegevens
-      | code | omschrijving | nieuwe code | datum einde |
-      | 9999 | Ons Dorp     | 0800        | 20230526    |
+      | code | omschrijving |
+      | 9999 | Ons Dorp     |
       En adres 'A3' heeft de volgende gegevens
       | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
       | 9999                 | 9999010000000003                         |
-      En adres 'A4' heeft de volgende gegevens
-      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
-      | 0800                 | 9999010000000003                         |
       En de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A3' met de volgende gegevens
       | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
       | 9999                              | 20100818                           |
-      En de persoon is vervolgens ingeschreven op adres 'A4' met de volgende gegevens
-      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
-      | 0800                              | 20230526                           |
+      En de gemeente met code '9999' is samengevoegd met de volgende gegevens
+      | nieuwe gemeentecode (92.12) | datum beëindiging (99.99) |
+      | 0800                        | 20230526                  |
       Als gba bewoning wordt gezocht met de volgende parameters
       | naam                             | waarde               |
       | type                             | BewoningMetPeildatum |
@@ -232,6 +217,6 @@ Functionaliteit: autorisatie voor het gebruik van de API BewoningMetPeildatum
       Dan heeft de response 1 bewoning
 
       Voorbeelden:
-      | peildatum  | scenario                               |
-      | 2023-07-01 | peildatum ligt na datum samenvoeging   |
-      | 2023-01-01 | peildatum ligt voor datum samenvoeging |
+      | peildatum  | scenario                                                                            |
+      | 2023-07-01 | peildatum ligt na datum samenvoeging (adresseerbaar object ligt in gemeente 0800)   |
+      | 2023-01-01 | peildatum ligt voor datum samenvoeging (adresseerbaar object ligt in gemeente 9999) |

--- a/features/raadpleeg-bewoning-op-peildatum/gba/autorisatie-gba.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/gba/autorisatie-gba.feature
@@ -212,9 +212,6 @@ Functionaliteit: autorisatie voor het gebruik van de API BewoningMetPeildatum
       Gegeven een gemeente met de volgende gegevens
       | code | omschrijving | nieuwe code | datum einde |
       | 9999 | Ons Dorp     | 0800        | 20230526    |
-      En een gemeente met de volgende gegevens
-      | code | omschrijving          | nieuwe code | datum einde |
-      | 0800 | Samenvoegingsgemeente | 0800        |             |
       En adres 'A3' heeft de volgende gegevens
       | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
       | 9999                 | 9999010000000003                         |
@@ -235,6 +232,6 @@ Functionaliteit: autorisatie voor het gebruik van de API BewoningMetPeildatum
       Dan heeft de response 1 bewoning
 
       Voorbeelden:
-      | peildatum  | scenario                                     |
-      | 2023-07-01 | bewoning wordt gevraagd na de samenvoeging   |
-      | 2023-01-01 | bewoning wordt gevraagd voor de samenvoeging |
+      | peildatum  | scenario                               |
+      | 2023-07-01 | peildatum ligt na datum samenvoeging   |
+      | 2023-01-01 | peildatum ligt voor datum samenvoeging |


### PR DESCRIPTION
fixes #158 

rules die beschrijven hoe met autorisatie (bepalen of adresseerbaar object binnen de gemeente ligt) moet worden omgegaan wanneer door gemeentelijke herindeling of samenvoeging van gemeenten de gemeentecode van het adresseerbaar object is gewijzigd.