### PR TITLE
Correcties zonder onjuist

### DIFF
--- a/features/raadpleeg-bewoning-met-periode/gba/bewoning-samenstellingen-gba.feature
+++ b/features/raadpleeg-bewoning-met-periode/gba/bewoning-samenstellingen-gba.feature
@@ -307,7 +307,7 @@ Functionaliteit: Elke wijziging van de samenstelling van bewoners van een adress
       | 000000048           |
 
 
-  Rule: een correctie of wijziging waardoor er meerdere aaneensluitende verblijfplaatsen van hetzelfde adresseerbaar object zijn wordt dat als één bewoning gezien
+  Rule: meerdere aaneensluitende verblijfplaatsen op hetzelfde adresseerbaar object als gevolg van een correctie of wijziging, wordt als één bewoning gezien
     
     Scenario: <omschrijving>
       Gegeven adres 'A4' heeft de volgende gegevens

--- a/features/raadpleeg-bewoning-met-periode/gba/bewoning-samenstellingen-gba.feature
+++ b/features/raadpleeg-bewoning-met-periode/gba/bewoning-samenstellingen-gba.feature
@@ -305,3 +305,41 @@ Functionaliteit: Elke wijziging van de samenstelling van bewoners van een adress
       En heeft de bewoning een bewoner met de volgende gegevens
       | burgerservicenummer |
       | 000000048           |
+
+
+  Rule: een correctie of wijziging waardoor er meerdere aaneensluitende verblijfplaatsen van hetzelfde adresseerbaar object zijn wordt dat als één bewoning gezien
+    
+    Scenario: <omschrijving>
+      Gegeven adres 'A4' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+      | 0800                 | 0800010000000004                         |
+      En adres 'A5' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+      | 0800                 | 0800010000000005                         |
+      En de persoon met burgerservicenummer '000000085' is ingeschreven op adres 'A4' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20100818                           |
+      En de persoon is vervolgens ingeschreven op adres 'A5' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20210526                           |
+      En de persoon is vervolgens ingeschreven op adres 'A4' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | <datum aanvang volgende>           |
+      Als gba bewoning wordt gezocht met de volgende parameters
+      | naam                             | waarde             |
+      | type                             | BewoningMetPeriode |
+      | datumVan                         | 2021-01-01         |
+      | datumTot                         | 2022-01-01         |
+      | adresseerbaarObjectIdentificatie | 0800010000000004   |
+      Dan heeft de response een bewoning met de volgende gegevens
+      | naam                             | waarde                    |
+      | periode                          | 2021-01-01 tot 2022-01-01 |
+      | adresseerbaarObjectIdentificatie | 0800010000000004          |
+      En heeft de bewoning een bewoner met de volgende gegevens
+      | burgerservicenummer |
+      | 000000085           |
+
+      Voorbeelden:
+      | datum aanvang volgende | omschrijving                                                                         |
+      | 20210526               | datum aanvang is gelijk aan datum aanvang adres waar persoon nooit gewoond heeft     |
+      | 20100818               | datum aanvang is gelijk aan datum aanvang oorspronkelijke verblijf op gevraagd adres |

--- a/features/raadpleeg-bewoning-met-periode/gba/onjuist-gba.feature
+++ b/features/raadpleeg-bewoning-met-periode/gba/onjuist-gba.feature
@@ -93,3 +93,28 @@ Functionaliteit: raadpleeg bewoning in een periode van een gecorrigeerde verblij
       En heeft de bewoning een bewoner met de volgende gegevens
       | burgerservicenummer |
       | 000000024           |
+
+  Rule: wanneer datum aanvang volgende gelijk is aan of eerder ligt dan datum aanvang gevraagde verblijf, is de persoon er geen bewoner
+
+    Scenario: <scenario>
+      Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20100818                           |
+      En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20210526                           |
+      En de persoon is vervolgens ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | <datum aanvang volgende>           |
+      Als gba bewoning wordt gezocht met de volgende parameters
+      | naam                             | waarde             |
+      | type                             | BewoningMetPeriode |
+      | datumVan                         | 2021-01-01         |
+      | datumTot                         | 2022-01-01         |
+      | adresseerbaarObjectIdentificatie | 0800010000000002   |
+      Dan heeft de response 0 bewoningen
+
+      Voorbeelden:
+      | datum aanvang volgende | scenario                                                                       |
+      | 20210526               | datum aanvang volgende verblijf is gelijk aan datum aanvang gevraagde verblijf |
+      | 20201229               | datum aanvang volgende verblijf ligt voor datum aanvang gevraagde verblijf     |

--- a/features/raadpleeg-bewoning-met-periode/gba/onjuist-gba.feature
+++ b/features/raadpleeg-bewoning-met-periode/gba/onjuist-gba.feature
@@ -103,7 +103,7 @@ Functionaliteit: raadpleeg bewoning in een periode van een gecorrigeerde verblij
       En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
       | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
       | 0800                              | 20210526                           |
-      En de persoon is vervolgens ingeschreven op adres 'A1' met de volgende gegevens
+      En de persoon is vervolgens ingeschreven op adres 'A3' met de volgende gegevens
       | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
       | 0800                              | <datum aanvang volgende>           |
       Als gba bewoning wordt gezocht met de volgende parameters

--- a/features/raadpleeg-bewoning-op-peildatum/gba/onjuist-gba.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/gba/onjuist-gba.feature
@@ -185,3 +185,27 @@ Functionaliteit: raadpleeg bewoning van een gecorrigeerde verblijfplaats
       | peildatum                        | 2016-02-01           |
       | adresseerbaarObjectIdentificatie | 0800010000000002     |
       Dan heeft de response 0 bewoningen
+
+  Rule: wanneer datum aanvang volgende gelijk is aan of eerder ligt dan datum aanvang gevraagde verblijf, is de persoon er geen bewoner
+
+    Scenario: <scenario>
+      Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20100818                           |
+      En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20210526                           |
+      En de persoon is vervolgens ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | <datum aanvang volgende>           |
+      Als gba bewoning wordt gezocht met de volgende parameters
+      | naam                             | waarde               |
+      | type                             | BewoningMetPeildatum |
+      | peildatum                        | 2021-05-26           |
+      | adresseerbaarObjectIdentificatie | 0800010000000002     |
+      Dan heeft de response 0 bewoningen
+
+      Voorbeelden:
+      | datum aanvang volgende | scenario                                                                       |
+      | 20210526               | datum aanvang volgende verblijf is gelijk aan datum aanvang gevraagde verblijf |
+      | 20201229               | datum aanvang volgende verblijf ligt voor datum aanvang gevraagde verblijf     |

--- a/features/raadpleeg-bewoning-op-peildatum/gba/onjuist-gba.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/gba/onjuist-gba.feature
@@ -195,7 +195,7 @@ Functionaliteit: raadpleeg bewoning van een gecorrigeerde verblijfplaats
       En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
       | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
       | 0800                              | 20210526                           |
-      En de persoon is vervolgens ingeschreven op adres 'A1' met de volgende gegevens
+      En de persoon is vervolgens ingeschreven op adres 'A3' met de volgende gegevens
       | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
       | 0800                              | <datum aanvang volgende>           |
       Als gba bewoning wordt gezocht met de volgende parameters


### PR DESCRIPTION
het blijkt voor te komen dat er wijzigingen worden doorgevoerd die eigelijk als correctie (indicatie onjuist) hadden moeten worden verwerkt.

Hierdoor kunnen er achtereenvolgens niet-onjuiste voorkomens (historische categorieën) van verblijfplaats zijn die elkaar overlappen of overschrijven. Datum aanvang van de volgende verblijfplaats is dus niet altijd hoger (latere datum) dan de datum aanvang van de gevraagde verblijfplaats.

In feature(s) onjuist en in bewoning-samenstellingen heb ik hiervoor een rule toegevoegd met bijbehorend scenario