### PR TITLE
chore(specs): deels opschorting periode overlap scenarios

### DIFF
--- a/features/raadpleeg-bewoning-met-periode/gba/opschorting-bijhouding-gba.feature
+++ b/features/raadpleeg-bewoning-met-periode/gba/opschorting-bijhouding-gba.feature
@@ -73,6 +73,35 @@ Rule: personen met opschorting bijhouding met aanduiding ongelijk aan "F" of "W"
     | R                            | pl is aangelegd in de rni      |
     | .                            | onbekend                       |
 
+  Abstract Scenario: persoon is opgeschort met reden "<reden opschorting bijhouding>" (<reden opschorting omschrijving>) en gevraagde periode begint vóór- en eindigt na datum opschorting bijhouding
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100818                           |
+    En de persoon heeft de volgende 'inschrijving' gegevens
+    | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+    | 20220829                             | <reden opschorting bijhouding>       |
+    Als gba bewoning wordt gezocht met de volgende parameters
+    | naam                             | waarde             |
+    | type                             | BewoningMetPeriode |
+    | datumVan                         | 2022-01-01         |
+    | datumTot                         | 2023-01-01         |
+    | adresseerbaarObjectIdentificatie | 0800010000000001   |
+    Dan heeft de response een bewoning met de volgende gegevens
+    | naam                             | waarde                    |
+    | periode                          | 2022-01-01 tot 2022-08-29 |
+    | adresseerbaarObjectIdentificatie | 0800010000000001          |
+    En heeft de bewoning een bewoner met de volgende gegevens
+    | burgerservicenummer |
+    | 000000024           |
+
+    Voorbeelden:
+    | reden opschorting bijhouding | reden opschorting omschrijving |
+    | O                            | overlijden                     |
+    | E                            | emigratie                      |
+    | M                            | ministerieel besluit           |
+    | R                            | pl is aangelegd in de rni      |
+    | .                            | onbekend                       |
+
   Abstract Scenario: persoon is opgeschort met reden "<reden opschorting bijhouding>" (<reden opschorting omschrijving>) en <scenario>
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |


### PR DESCRIPTION
Als de rule

```
personen met opschorting bijhouding met aanduiding ongelijk aan "F" of "W" worden na datum opschorting bijhouding niet gezien als bewoner
```

goed wordt geïnterpreteerd, dan zou voor een gevraagde periode dat de opschorting periode overlapt, voor de periode vóór datum opschorting wel bewoning moeten worden geleverd. Dat wordt geïllustreerd met de toegevoegde scenarios