### PR TITLE
features voor beschrijven dat burgerservicenummer van de persoon moet worden geleverd

### DIFF
--- a/features/raadpleeg-bewoning-met-periode/gba/bewoner-gba.feature
+++ b/features/raadpleeg-bewoning-met-periode/gba/bewoner-gba.feature
@@ -1,0 +1,76 @@
+#language: nl
+
+@gba
+Functionaliteit: lever burgerservicenummer van bewoner(s) bij raadpleeg bewoning met periode
+
+    Scenario: de persoon heeft ouders, partners en kinderen die zijn ingeschreven in de BRP
+      Gegeven adres 'A1' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+      | 0800                 | 0800010000000001                         |
+      En de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20100818                           |
+      En de persoon heeft een ouder '1' met de volgende gegevens
+      | naam                        | waarde    |
+      | burgerservicenummer (01.20) | 000000024 |
+      En de persoon heeft een ouder '2' met de volgende gegevens
+      | naam                        | waarde    |
+      | burgerservicenummer (01.20) | 000000036 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                        | waarde    |
+      | burgerservicenummer (01.20) | 000000048 |
+      En de persoon heeft een 'kind' met de volgende gegevens
+      | naam                        | waarde    |
+      | burgerservicenummer (01.20) | 000000061 |
+      En de persoon heeft een 'kind' met de volgende gegevens
+      | naam                        | waarde    |
+      | burgerservicenummer (01.20) | 000000073 |
+      Als gba bewoning wordt gezocht met de volgende parameters
+      | naam                             | waarde             |
+      | type                             | BewoningMetPeriode |
+      | datumVan                         | 2021-01-01         |
+      | datumTot                         | 2022-01-01         |
+      | adresseerbaarObjectIdentificatie | 0800010000000001   |
+      Dan heeft de response een bewoning met de volgende gegevens
+      | naam                             | waarde                    |
+      | periode                          | 2021-01-01 tot 2022-01-01 |
+      | adresseerbaarObjectIdentificatie | 0800010000000001          |
+      En heeft de bewoning een bewoner met de volgende gegevens
+      | burgerservicenummer |
+      | 000000012           |
+
+    Scenario: de persoon heeft ouders, partners en kinderen die niet zijn ingeschreven in de BRP
+      Gegeven adres 'A1' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+      | 0800                 | 0800010000000001                         |
+      En de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20100818                           |
+      En de persoon heeft een ouder '1' met de volgende gegevens
+      | naam                  | waarde |
+      | geslachtsnaam (02.40) | moeder |
+      En de persoon heeft een ouder '2' met de volgende gegevens
+      | naam                  | waarde |
+      | geslachtsnaam (02.40) | vader  |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                  | waarde  |
+      | geslachtsnaam (02.40) | partner |
+      En de persoon heeft een 'kind' met de volgende gegevens
+      | naam                  | waarde |
+      | geslachtsnaam (02.40) | kind   |
+      En de persoon heeft een 'kind' met de volgende gegevens
+      | naam                  | waarde |
+      | geslachtsnaam (02.40) | kind   |
+      Als gba bewoning wordt gezocht met de volgende parameters
+      | naam                             | waarde             |
+      | type                             | BewoningMetPeriode |
+      | datumVan                         | 2021-01-01         |
+      | datumTot                         | 2022-01-01         |
+      | adresseerbaarObjectIdentificatie | 0800010000000001   |
+      Dan heeft de response een bewoning met de volgende gegevens
+      | naam                             | waarde                    |
+      | periode                          | 2021-01-01 tot 2022-01-01 |
+      | adresseerbaarObjectIdentificatie | 0800010000000001          |
+      En heeft de bewoning een bewoner met de volgende gegevens
+      | burgerservicenummer |
+      | 000000012           |

--- a/features/raadpleeg-bewoning-op-peildatum/gba/bewoner-gba.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/gba/bewoner-gba.feature
@@ -1,0 +1,74 @@
+#language: nl
+
+@gba
+Functionaliteit: lever burgerservicenummer van bewoner(s) bij raadpleeg bewoning op peildatum
+
+    Scenario: de persoon heeft ouders, partners en kinderen die zijn ingeschreven in de BRP
+      Gegeven adres 'A1' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+      | 0800                 | 0800010000000001                         |
+      En de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20100818                           |
+      En de persoon heeft een ouder '1' met de volgende gegevens
+      | naam                        | waarde    |
+      | burgerservicenummer (01.20) | 000000024 |
+      En de persoon heeft een ouder '2' met de volgende gegevens
+      | naam                        | waarde    |
+      | burgerservicenummer (01.20) | 000000036 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                        | waarde    |
+      | burgerservicenummer (01.20) | 000000048 |
+      En de persoon heeft een 'kind' met de volgende gegevens
+      | naam                        | waarde    |
+      | burgerservicenummer (01.20) | 000000061 |
+      En de persoon heeft een 'kind' met de volgende gegevens
+      | naam                        | waarde    |
+      | burgerservicenummer (01.20) | 000000073 |
+      Als gba bewoning wordt gezocht met de volgende parameters
+      | naam                             | waarde               |
+      | type                             | BewoningMetPeildatum |
+      | peildatum                        | 2021-01-01           |
+      | adresseerbaarObjectIdentificatie | 0800010000000001     |
+      Dan heeft de response een bewoning met de volgende gegevens
+      | naam                             | waarde                    |
+      | periode                          | 2021-01-01 tot 2021-01-02 |
+      | adresseerbaarObjectIdentificatie | 0800010000000001          |
+      En heeft de bewoning een bewoner met de volgende gegevens
+      | burgerservicenummer |
+      | 000000012           |
+
+    Scenario: de persoon heeft ouders, partners en kinderen die niet zijn ingeschreven in de BRP
+      Gegeven adres 'A1' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+      | 0800                 | 0800010000000001                         |
+      En de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20100818                           |
+      En de persoon heeft een ouder '1' met de volgende gegevens
+      | naam                  | waarde |
+      | geslachtsnaam (02.40) | moeder |
+      En de persoon heeft een ouder '2' met de volgende gegevens
+      | naam                  | waarde |
+      | geslachtsnaam (02.40) | vader  |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                  | waarde  |
+      | geslachtsnaam (02.40) | partner |
+      En de persoon heeft een 'kind' met de volgende gegevens
+      | naam                  | waarde |
+      | geslachtsnaam (02.40) | kind   |
+      En de persoon heeft een 'kind' met de volgende gegevens
+      | naam                  | waarde |
+      | geslachtsnaam (02.40) | kind   |
+      Als gba bewoning wordt gezocht met de volgende parameters
+      | naam                             | waarde               |
+      | type                             | BewoningMetPeildatum |
+      | peildatum                        | 2021-01-01           |
+      | adresseerbaarObjectIdentificatie | 0800010000000001     |
+      Dan heeft de response een bewoning met de volgende gegevens
+      | naam                             | waarde                    |
+      | periode                          | 2021-01-01 tot 2021-01-02 |
+      | adresseerbaarObjectIdentificatie | 0800010000000001          |
+      En heeft de bewoning een bewoner met de volgende gegevens
+      | burgerservicenummer |
+      | 000000012           |

--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -589,6 +589,16 @@ Given(/^de inschrijving is vervolgens gecorrigeerd als een inschrijving op adres
     ].concat(createArrayFrom(dataTable, columnNameMap)));
 });
 
+async function createOuder(ouderType, dataTable) {
+    let sqlData = this.context.sqlData.at(-1);
+
+    sqlData[`ouder-${ouderType}`] = [
+        createCollectieDataFromArray(ouderType, createArrayFrom(dataTable, columnNameMap))
+    ];
+}
+
+Given(/^de persoon heeft een ouder '(\d)' met de volgende gegevens$/, createOuder);
+
 async function handleRequest(context, dataTable) {
     if(context.sqlData === undefined) {
         context.sqlData = [{}];


### PR DESCRIPTION
… en dus niet burgerservicenummer van een ouder, partner of kind

@CathyDingemanse  @MelvLee ik heb er geen rule boven gezet, geen inspiratie hoe je dat zou moeten opschrijven...

@MelvLee de Gegeven stap voor ouders heb ik toegevoegd aan step_definitions (gekopiëerd van BRP Personen bevragen). Lijkt te werken (genereert de juiste inserts).

Scenario's lopen fout, dat is m.i. een bug in de API die moet worden opgelost. De API levert nu het burgerservicenummer van ouder 1.