### PR TITLE
scenario gewijzigde persoon met verschillende datums

### DIFF
--- a/features/raadpleeg-bewoning-met-periode/gba/bewoner-met-relaties-gba.feature
+++ b/features/raadpleeg-bewoning-met-periode/gba/bewoner-met-relaties-gba.feature
@@ -110,34 +110,6 @@ Functionaliteit: bepalen van de bewoner bij personen met kind, ouder en/of partn
       | burgerservicenummer |
       | 000000012           |
 
-    Scenario: gegevens van de persoon zijn gewijzigd
-      Gegeven adres 'A1' heeft de volgende gegevens
-      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
-      | 0800                 | 0800010000000001                         |
-      En de persoon met burgerservicenummer '000000012' heeft de volgende gegevens
-      | naam                           | waarde |
-      | aanduiding naamgebruik (61.10) | E      |
-      En de persoon is gewijzigd naar de volgende gegevens
-      | naam                           | waarde    |
-      | burgerservicenummer (01.20)    | 000000024 |
-      | aanduiding naamgebruik (61.10) | V         |
-      En de persoon is ingeschreven op adres 'A1' met de volgende gegevens
-      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
-      | 0800                              | 20210102                           |
-      Als gba bewoning wordt gezocht met de volgende parameters
-      | naam                             | waarde             |
-      | type                             | BewoningMetPeriode |
-      | datumVan                         | 2022-01-01         |
-      | datumTot                         | 2022-03-01         |
-      | adresseerbaarObjectIdentificatie | 0800010000000001   |
-      Dan heeft de response een bewoning met de volgende gegevens
-      | naam                             | waarde                    |
-      | periode                          | 2022-01-01 tot 2022-03-01 |
-      | adresseerbaarObjectIdentificatie | 0800010000000001          |
-      En heeft de bewoning een bewoner met de volgende gegevens
-      | burgerservicenummer |
-      | 000000024           |
-
     Abstract Scenario: gegevens van de persoon zijn gewijzigd
       Gegeven adres 'A1' heeft de volgende gegevens
       | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |

--- a/features/raadpleeg-bewoning-met-periode/gba/bewoner-met-relaties-gba.feature
+++ b/features/raadpleeg-bewoning-met-periode/gba/bewoner-met-relaties-gba.feature
@@ -137,3 +137,45 @@ Functionaliteit: bepalen van de bewoner bij personen met kind, ouder en/of partn
       En heeft de bewoning een bewoner met de volgende gegevens
       | burgerservicenummer |
       | 000000024           |
+
+    Abstract Scenario: gegevens van de persoon zijn gewijzigd
+      Gegeven adres 'A1' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+      | 0800                 | 0800010000000001                         |
+      En adres 'A2' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+      | 0800                 | 0800010000000002                         |
+      En de persoon met burgerservicenummer '000000012' heeft de volgende gegevens
+      | naam                           | waarde |
+      | aanduiding naamgebruik (61.10) | E      |
+      En de persoon is gewijzigd naar de volgende gegevens
+      | naam                           | waarde    |
+      | burgerservicenummer (01.20)    | 000000024 |
+      | aanduiding naamgebruik (61.10) | V         |
+      En de persoon is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20200526                           |
+      En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20221014                           |
+      Als gba bewoning wordt gezocht met de volgende parameters
+      | naam                             | waarde             |
+      | type                             | BewoningMetPeriode |
+      | datumVan                         | <datumVan>         |
+      | datumTot                         | <datumTot>         |
+      | adresseerbaarObjectIdentificatie | 0800010000000001   |
+      Dan heeft de response een bewoning met de volgende gegevens
+      | naam                             | waarde           |
+      | periode                          | <periode>        |
+      | adresseerbaarObjectIdentificatie | 0800010000000001 |
+      En heeft de bewoning een bewoner met de volgende gegevens
+      | burgerservicenummer |
+      | 000000024           |
+
+      Voorbeelden:
+      | datumVan   | datumTot   | periode                   | testgeval                      |
+      | 2020-05-26 | 2020-06-01 | 2020-05-26 tot 2020-06-01 | vanaf eerste dag bewoning      |
+      | 2020-05-01 | 2020-05-27 | 2020-05-26 tot 2020-05-27 | tot en met eerste dag bewoning |
+      | 2021-01-01 | 2022-01-01 | 2021-01-01 tot 2022-01-01 | in bewoning                    |
+      | 2022-10-13 | 2022-11-14 | 2022-10-13 tot 2022-10-14 | vanaf laatste dag bewoning     |
+      | 2020-05-01 | 2022-11-01 | 2020-05-26 tot 2022-10-14 | overlapt hele bewoning         |

--- a/features/raadpleeg-bewoning-op-peildatum/gba/bewoner-met-relaties-gba.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/gba/bewoner-met-relaties-gba.feature
@@ -107,10 +107,13 @@ Functionaliteit: bepalen van de bewoner op peildatum bij personen met kind, oude
       | burgerservicenummer |
       | 000000012           |
 
-    Scenario: gegevens van de persoon zijn gewijzigd
+    Abstract Scenario: gegevens van de persoon zijn gewijzigd
       Gegeven adres 'A1' heeft de volgende gegevens
       | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
       | 0800                 | 0800010000000001                         |
+      En adres 'A2' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+      | 0800                 | 0800010000000002                         |
       En de persoon met burgerservicenummer '000000012' heeft de volgende gegevens
       | naam                           | waarde |
       | aanduiding naamgebruik (61.10) | E      |
@@ -120,16 +123,25 @@ Functionaliteit: bepalen van de bewoner op peildatum bij personen met kind, oude
       | aanduiding naamgebruik (61.10) | V         |
       En de persoon is ingeschreven op adres 'A1' met de volgende gegevens
       | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
-      | 0800                              | 20210102                           |
+      | 0800                              | 20200526                           |
+      En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20221014                           |
       Als gba bewoning wordt gezocht met de volgende parameters
       | naam                             | waarde               |
       | type                             | BewoningMetPeildatum |
-      | peildatum                        | 2022-01-01           |
+      | peildatum                        | <peildatum>          |
       | adresseerbaarObjectIdentificatie | 0800010000000001     |
       Dan heeft de response een bewoning met de volgende gegevens
       | naam                             | waarde                    |
-      | periode                          | 2022-01-01 tot 2022-01-02 |
+      | periode                          | <periode>                 |
       | adresseerbaarObjectIdentificatie | 0800010000000001          |
       En heeft de bewoning een bewoner met de volgende gegevens
       | burgerservicenummer |
       | 000000024           |
+
+      Voorbeelden:
+      | peildatum  | periode                   | testgeval            |
+      | 2020-05-26 | 2020-05-26 tot 2020-05-27 | eerste dag bewoning  |
+      | 2021-01-01 | 2021-01-01 tot 2021-01-02 | in bewoning          |
+      | 2022-10-13 | 2022-10-13 tot 2022-10-14 | laatste dag bewoning |


### PR DESCRIPTION
n.a.v. testbevinding

met versie v2.0.12 wordt voor peildatum=datum aanvang adreshouding alle voorkomens van de persoon geleverd, terwijl alleen de actuele geleverd moet worden.