### PR TITLE
scenario's mogelijke bewoner in combinatie met opschorting bijhouding

### DIFF
--- a/features/raadpleeg-bewoning-met-periode/gba/mogelijke-bewoner-gba.feature
+++ b/features/raadpleeg-bewoning-met-periode/gba/mogelijke-bewoner-gba.feature
@@ -666,6 +666,72 @@ Rule: een persoon met bekende aanvang vorige adreshouding die in de onzekerheids
     | 20101014                          | 00000000                   | 2010-04-01 | 2010-10-01 |
     | 20101014                          | 00000000                   | 2010-10-13 | 2010-10-15 |
 
+
+Rule: een persoon met bekende aanvang vorige adreshouding en bekende aanvang volgende adreshouding die beide in de onzekerheidsperiode van de onbekende aanvang adreshouding ligt, is een mogelijke bewoner voor het deel van de periode dat in de onzekerheidsperiode na de datum aanvang vorige adreshouding en voor datum aanvang volgende adreshouding ligt
+
+  Abstract Scenario: datum aanvang vorige adreshouding en datum aanvang volgende adreshouding liggen in onzekerheidsperiode van onbekende aanvang adreshouding en periode ligt in de onzekerheidsperiode van gevraagde adreshouding
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30)  |
+    | 0800                              | <datum aanvang vorige adreshouding> |
+    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | <datum aanvang adreshouding>       |
+    En de persoon is vervolgens ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30)    |
+    | 0800                              | <datum aanvang volgende adreshouding> |
+    Als gba bewoning wordt gezocht met de volgende parameters
+    | naam                             | waarde             |
+    | type                             | BewoningMetPeriode |
+    | datumVan                         | 2010-01-01         |
+    | datumTot                         | 2011-01-01         |
+    | adresseerbaarObjectIdentificatie | 0800010000000002   |
+    Dan heeft de response een bewoning met de volgende gegevens
+    | naam                             | waarde           |
+    | periode                          | <periode>        |
+    | adresseerbaarObjectIdentificatie | 0800010000000002 |
+    En heeft de bewoning een mogelijke bewoner met de volgende gegevens
+    | burgerservicenummer |
+    | 000000024           |
+
+    Voorbeelden:
+    | datum aanvang vorige adreshouding | datum aanvang adreshouding | datum aanvang volgende adreshouding | periode                   |
+    | 20100810                          | 20100800                   | 20100827                            | 2010-08-11 tot 2010-08-27 |
+    | 20100501                          | 20100000                   | 20101203                            | 2010-05-02 tot 2010-12-03 |
+    | 20100501                          | 00000000                   | 20101203                            | 2010-05-02 tot 2010-12-03 |
+
+  Abstract Scenario: datum aanvang vorige adreshouding en datum aanvang volgende adreshouding liggen in onzekerheidsperiode van onbekende aanvang adreshouding en periode ligt in de onzekerheidsperiode van gevraagde adreshouding <scenario>
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30)  |
+    | 0800                              | <datum aanvang vorige adreshouding> |
+    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | <datum aanvang adreshouding>       |
+    En de persoon is vervolgens ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30)    |
+    | 0800                              | <datum aanvang volgende adreshouding> |
+    Als gba bewoning wordt gezocht met de volgende parameters
+    | naam                             | waarde             |
+    | type                             | BewoningMetPeriode |
+    | datumVan                         | <datum van>        |
+    | datumTot                         | <datum tot>        |
+    | adresseerbaarObjectIdentificatie | 0800010000000002   |
+    Dan heeft de response 0 bewoningen
+
+    Voorbeelden:
+    | datum aanvang vorige adreshouding | datum aanvang adreshouding | datum aanvang volgende adreshouding | datum van  | datum tot  | scenario                                  |
+    | 20100810                          | 20100800                   | 20100827                            | 2010-07-01 | 2010-08-10 | tot datum aanvang vorige adreshouding     |
+    | 20100810                          | 20100800                   | 20100827                            | 2010-07-01 | 2010-08-09 | vóór datum aanvang vorige adreshouding    |
+    | 20100501                          | 20100000                   | 20101203                            | 2010-04-01 | 2010-05-01 | tot datum aanvang vorige adreshouding     |
+    | 20100501                          | 20100000                   | 20101203                            | 2010-04-01 | 2010-04-30 | vóór datum aanvang vorige adreshouding    |
+    | 20101014                          | 00000000                   | 20160301                            | 2010-04-01 | 2010-10-14 | tot datum aanvang vorige adreshouding     |
+    | 20101014                          | 00000000                   | 20160301                            | 2010-04-01 | 2010-10-13 | vóór datum aanvang vorige adreshouding    |
+    | 20100810                          | 20100800                   | 20100827                            | 2010-08-27 | 2010-11-30 | vanaf datum aanvang volgende adreshouding |
+    | 20100810                          | 20100800                   | 20100827                            | 2010-08-29 | 2010-11-30 | na datum aanvang volgende adreshouding    |
+    | 20100501                          | 20100000                   | 20101203                            | 2010-12-03 | 2011-01-01 | vanaf datum aanvang volgende adreshouding |
+    | 20100501                          | 20100000                   | 20101203                            | 2010-12-17 | 2011-01-01 | na datum aanvang volgende adreshouding    |
+    | 20101014                          | 00000000                   | 20160301                            | 2016-03-01 | 2016-05-01 | vanaf datum aanvang volgende adreshouding |
+    | 20101014                          | 00000000                   | 20160301                            | 2020-01-01 | 2021-01-01 | na datum aanvang volgende adreshouding    |
+
 Rule: een persoon met deels onbekende aanvang adreshouding, deels onbekende aanvang vorige adreshouding en niet-overlappende onzekerheidsperiodes, is een mogelijke bewoner voor het deel van de periode dat in de onzekerheidsperiode van de gevraagde adreshouding ligt
 
   Abstract Scenario: onzekerheidsperiode van deels onbekende aanvang adreshouding overlapt onzekerheidsperiode van deels onbekende aanvang vorige adreshouding niet en periode ligt in de onzekerheidsperiode van gevraagde adreshouding

--- a/features/raadpleeg-bewoning-op-peildatum/gba/mogelijke-bewoner-gba.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/gba/mogelijke-bewoner-gba.feature
@@ -202,6 +202,32 @@ Rule: een persoon met bekende aanvang volgende adreshouding die in de onzekerhei
     | 00000000                   | 20100101                            | 2010-01-01 |
     | 00000000                   | 20100101                            | 2010-01-02 |
 
+  Abstract Scenario: datum aanvang volgende adreshouding ligt in de onzekerheidsperiode van onbekende adreshouding en peildatum ligt op/na datum aanvang volgende adreshouding en er is opschorting bijhouding na de onzekerheidsperiode
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | <datum aanvang adreshouding>       |
+    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30)    |
+    | 0800                              | <datum aanvang volgende adreshouding> |
+    En de persoon heeft de volgende 'inschrijving' gegevens
+    | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+    | 20120730                             | O                                    |
+    Als gba bewoning wordt gezocht met de volgende parameters
+    | naam                             | waarde               |
+    | type                             | BewoningMetPeildatum |
+    | peildatum                        | <peildatum>          |
+    | adresseerbaarObjectIdentificatie | 0800010000000001     |
+    Dan heeft de response 0 bewoningen
+
+    Voorbeelden:
+    | datum aanvang adreshouding | datum aanvang volgende adreshouding | peildatum  |
+    | 20100800                   | 20100821                            | 2010-08-21 |
+    | 20100800                   | 20100821                            | 2011-05-26 |
+    | 20100000                   | 20101001                            | 2010-10-01 |
+    | 20100000                   | 20101001                            | 2011-05-26 |
+    | 00000000                   | 20100101                            | 2010-01-01 |
+    | 00000000                   | 20100101                            | 2011-05-26 |
+
 Rule: een persoon met bekende aanvang adreshouding die niet in de onzekerheidsperiode van de deels onbekende aanvang volgende adreshouding ligt, is op peildatum een mogelijke bewoner als de peildatum in de onzekerheidsperiode van het volgende adreshouding ligt
 
   Abstract Scenario: datum aanvang adreshouding ligt niet in de onzekerheidsperiode van het deels onbekende aanvang volgend adreshouding en peildatum ligt in de onzekerheidsperiode van de volgende adreshouding

--- a/features/raadpleeg-bewoning-op-peildatum/gba/mogelijke-bewoner-gba.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/gba/mogelijke-bewoner-gba.feature
@@ -628,7 +628,7 @@ Rule: een persoon met bekend aanvang vorige adreshouding die in de onzekerheidsp
 
 Rule: een persoon met bekend aanvang vorige adreshouding en bekende aanvang volgende adreshouding die beide in de onzekerheidsperiode van de onbekende aanvang adreshouding ligt, is op peildatum een mogelijke bewoner als de peildatum in de onzekerheidsperiode na de datum aanvang vorige adreshouding en voor datum aanvang volgende adreshouding ligt
 
-Abstract Scenario: datum aanvang vorige adreshouding en datum aanvang volgende adreshouding liggen in onzekerheidsperiode van onbekende aanvang adreshouding en peildatum ligt in de onzekerheidsperiode van gevraagde adreshouding na datum aanvang vorige adreshouding en voor aanvang volgende adreshouding
+  Abstract Scenario: datum aanvang vorige adreshouding en datum aanvang volgende adreshouding liggen in onzekerheidsperiode van onbekende aanvang adreshouding en peildatum ligt in de onzekerheidsperiode van gevraagde adreshouding na datum aanvang vorige adreshouding en voor aanvang volgende adreshouding
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30)  |
     | 0800                              | <datum aanvang vorige adreshouding> |

--- a/features/raadpleeg-bewoning-op-peildatum/gba/mogelijke-bewoner-gba.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/gba/mogelijke-bewoner-gba.feature
@@ -201,31 +201,6 @@ Rule: een persoon met bekende aanvang volgende adreshouding die in de onzekerhei
     | 20100000                   | 20101001                            | 2010-10-02 |
     | 00000000                   | 20100101                            | 2010-01-01 |
     | 00000000                   | 20100101                            | 2010-01-02 |
-
-  Abstract Scenario: datum aanvang volgende adreshouding ligt in de onzekerheidsperiode van onbekende adreshouding en peildatum ligt op/na datum aanvang volgende adreshouding en er is opschorting bijhouding na de onzekerheidsperiode
-    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
-    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
-    | 0800                              | <datum aanvang adreshouding>       |
-    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
-    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30)    |
-    | 0800                              | <datum aanvang volgende adreshouding> |
-    En de persoon heeft de volgende 'inschrijving' gegevens
-    | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
-    | 20120730                             | O                                    |
-    Als gba bewoning wordt gezocht met de volgende parameters
-    | naam                             | waarde               |
-    | type                             | BewoningMetPeildatum |
-    | peildatum                        | <peildatum>          |
-    | adresseerbaarObjectIdentificatie | 0800010000000001     |
-    Dan heeft de response 0 bewoningen
-
-    Voorbeelden:
-    | datum aanvang adreshouding | datum aanvang volgende adreshouding | peildatum  |
-    | 20100800                   | 20100821                            | 2010-08-21 |
-    | 20100800                   | 20100821                            | 2011-05-26 |
-    | 20100000                   | 20101001                            | 2010-10-01 |
-    | 20100000                   | 20101001                            | 2011-05-26 |
-    | 00000000                   | 20100101                            | 2010-01-01 |
     | 00000000                   | 20100101                            | 2011-05-26 |
 
 Rule: een persoon met bekende aanvang adreshouding die niet in de onzekerheidsperiode van de deels onbekende aanvang volgende adreshouding ligt, is op peildatum een mogelijke bewoner als de peildatum in de onzekerheidsperiode van het volgende adreshouding ligt

--- a/features/raadpleeg-bewoning-op-peildatum/gba/mogelijke-bewoner-gba.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/gba/mogelijke-bewoner-gba.feature
@@ -626,6 +626,69 @@ Rule: een persoon met bekend aanvang vorige adreshouding die in de onzekerheidsp
     | 20101014                          | 00000000                   | 2010-10-14 |
     | 20101014                          | 00000000                   | 2010-10-13 |
 
+Rule: een persoon met bekend aanvang vorige adreshouding en bekende aanvang volgende adreshouding die beide in de onzekerheidsperiode van de onbekende aanvang adreshouding ligt, is op peildatum een mogelijke bewoner als de peildatum in de onzekerheidsperiode na de datum aanvang vorige adreshouding en voor datum aanvang volgende adreshouding ligt
+
+Abstract Scenario: datum aanvang vorige adreshouding en datum aanvang volgende adreshouding liggen in onzekerheidsperiode van onbekende aanvang adreshouding en peildatum ligt in de onzekerheidsperiode van gevraagde adreshouding na datum aanvang vorige adreshouding en voor aanvang volgende adreshouding
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30)  |
+    | 0800                              | <datum aanvang vorige adreshouding> |
+    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | <datum aanvang adreshouding>       |
+    En de persoon is vervolgens ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30)    |
+    | 0800                              | <datum aanvang volgende adreshouding> |
+    Als gba bewoning wordt gezocht met de volgende parameters
+    | naam                             | waarde               |
+    | type                             | BewoningMetPeildatum |
+    | peildatum                        | <peildatum>          |
+    | adresseerbaarObjectIdentificatie | 0800010000000002     |
+    Dan heeft de response een bewoning met de volgende gegevens
+    | naam                             | waarde           |
+    | periode                          | <periode>        |
+    | adresseerbaarObjectIdentificatie | 0800010000000002 |
+    En heeft de bewoning een mogelijke bewoner met de volgende gegevens
+    | burgerservicenummer |
+    | 000000024           |
+
+    Voorbeelden:
+    | datum aanvang vorige adreshouding | datum aanvang adreshouding | datum aanvang volgende adreshouding | peildatum  | periode                   |
+    | 20100810                          | 20100800                   | 20100827                            | 2010-08-11 | 2010-08-11 tot 2010-08-12 |
+    | 20100501                          | 20100000                   | 20101203                            | 2010-05-02 | 2010-05-02 tot 2010-05-03 |
+    | 20100501                          | 00000000                   | 20160301                            | 2012-10-15 | 2012-10-15 tot 2012-10-16 |
+
+  Abstract Scenario: datum aanvang vorige adreshouding ligt in onzekerheidsperiode van onbekende aanvang adreshouding en peildatum ligt in de onzekerheidsperiode van gevraagde adreshouding <scenario>
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30)  |
+    | 0800                              | <datum aanvang vorige adreshouding> |
+    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | <datum aanvang adreshouding>       |
+    En de persoon is vervolgens ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30)    |
+    | 0800                              | <datum aanvang volgende adreshouding> |
+    Als gba bewoning wordt gezocht met de volgende parameters
+    | naam                             | waarde               |
+    | type                             | BewoningMetPeildatum |
+    | peildatum                        | <peildatum>          |
+    | adresseerbaarObjectIdentificatie | 0800010000000002     |
+    Dan heeft de response 0 bewoningen
+
+    Voorbeelden:
+    | datum aanvang vorige adreshouding | datum aanvang adreshouding | datum aanvang volgende adreshouding | peildatum  | scenario                               |
+    | 20100810                          | 20100800                   | 20100827                            | 2010-08-10 | op datum aanvang vorige adreshouding   |
+    | 20100810                          | 20100800                   | 20100827                            | 2010-08-09 | vóór datum aanvang vorige adreshouding |
+    | 20100501                          | 20100000                   | 20101203                            | 2010-05-01 | op datum aanvang vorige adreshouding   |
+    | 20100501                          | 20100000                   | 20101203                            | 2010-04-30 | vóór datum aanvang vorige adreshouding |
+    | 20101014                          | 00000000                   | 20160301                            | 2010-10-14 | op datum aanvang vorige adreshouding   |
+    | 20101014                          | 00000000                   | 20160301                            | 2010-10-13 | vóór datum aanvang vorige adreshouding |
+    | 20100810                          | 20100800                   | 20100827                            | 2010-08-27 | op datum aanvang volgende adreshouding |
+    | 20100810                          | 20100800                   | 20100827                            | 2010-08-29 | na datum aanvang volgende adreshouding |
+    | 20100501                          | 20100000                   | 20101203                            | 2010-12-03 | op datum aanvang volgende adreshouding |
+    | 20100501                          | 20100000                   | 20101203                            | 2010-12-17 | na datum aanvang volgende adreshouding |
+    | 20101014                          | 00000000                   | 20160301                            | 2016-03-01 | op datum aanvang volgende adreshouding |
+    | 20101014                          | 00000000                   | 20160301                            | 2020-01-01 | na datum aanvang volgende adreshouding |
+
 Rule: een persoon met deels onbekende aanvang adreshouding, deels onbekende aanvang vorige adreshouding en niet-overlappende onzekerheidsperiodes, is op peildatum een mogelijke bewoner als de peildatum in de onzekerheidsperiode van de gevraagde adreshouding ligt
 
   Abstract Scenario: onzekerheidsperiode van deels onbekende aanvang adreshouding overlapt onzekerheidsperiode van deels onbekende aanvang vorige adreshouding niet en peildatum ligt in de onzekerheidsperiode van gevraagde adreshouding

--- a/features/raadpleeg-bewoning-op-peildatum/gba/opschorting-bijhouding-gba.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/gba/opschorting-bijhouding-gba.feature
@@ -96,3 +96,49 @@ Rule: personen met opschorting bijhouding met aanduiding ongelijk aan "F" of "W"
     | R                            | pl is aangelegd in de rni      | 2022-09-01 | 2022-09-01 tot 2022-09-02 | peildatum ligt na datum opschorting bijhouding |
     | .                            | onbekend                       | 2022-08-29 | 2022-08-29 tot 2022-08-30 | peildatum ligt op datum opschorting bijhouding |
     | .                            | onbekend                       | 2022-09-01 | 2022-09-01 tot 2022-09-02 | peildatum ligt na datum opschorting bijhouding |
+
+  Abstract Scenario: <scenario>
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | <datum aanvang>                    |
+    En de persoon heeft de volgende 'inschrijving' gegevens
+    | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+    | <datum opschorting bijhouding>       | O                                    |
+    Als gba bewoning wordt gezocht met de volgende parameters
+    | naam                             | waarde               |
+    | type                             | BewoningMetPeildatum |
+    | peildatum                        | 2020-10-14           |
+    | adresseerbaarObjectIdentificatie | 0800010000000001     |
+    Dan heeft de response een bewoning met de volgende gegevens
+    | naam                             | waarde                    |
+    | periode                          | 2020-10-14 tot 2020-10-15 |
+    | adresseerbaarObjectIdentificatie | 0800010000000001          |
+    En heeft de bewoning een mogelijke bewoner met de volgende gegevens
+    | burgerservicenummer |
+    | 000000024           |
+
+    Voorbeelden:
+    | datum aanvang | datum opschorting bijhouding | scenario                                                                                                          |
+    | 20201000      | 20201016                     | datum aanvang heeft onbekende dag en peildatum valt binnen onzekerheidsperiode en voor datum opschorting          |
+    | 20200000      | 20201016                     | datum aanvang heeft onbekende dag en maand en peildatum valt binnen onzekerheidsperiode en voor datum opschorting |
+    | 00000000      | 20201016                     | datum aanvang heeft onbekende dag en peildatum valt binnen onzekerheidsperiode en voor datum opschorting          |
+
+  Abstract Scenario: <scenario>
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | <datum aanvang>                    |
+    En de persoon heeft de volgende 'inschrijving' gegevens
+    | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+    | <datum opschorting bijhouding>       | O                                    |
+    Als gba bewoning wordt gezocht met de volgende parameters
+    | naam                             | waarde               |
+    | type                             | BewoningMetPeildatum |
+    | peildatum                        | 2020-10-14           |
+    | adresseerbaarObjectIdentificatie | 0800010000000001     |
+    Dan heeft de response 0 bewoningen
+
+    Voorbeelden:
+    | datum aanvang | datum opschorting bijhouding | scenario                                                                                                        |
+    | 20201000      | 20201012                     | datum aanvang heeft onbekende dag en peildatum valt binnen onzekerheidsperiode en na datum opschorting          |
+    | 20200000      | 20200526                     | datum aanvang heeft onbekende dag en maand en peildatum valt binnen onzekerheidsperiode en na datum opschorting |
+    | 00000000      | 20190526                     | datum aanvang heeft onbekende dag en peildatum valt binnen onzekerheidsperiode en na datum opschorting          |


### PR DESCRIPTION
n.a.v. gevonden fout in test

@KayodeBakker scenario in mogelijke-bewoner-gba feature (peildatum) op regel 229 faalt op versie 2.0.13
@KayodeBakker scenario's in mogelijke-bewoner-gba feature (peildatum) op regel 631 falen op versie 2.0.13
@KayodeBakker scenario's in mogelijke-bewoner-gba feature (periode) op regel 672 falen op versie 2.0.13