### PR TITLE
chore(docs): README rechtgetrokken met index.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ API voor het raadplegen van de historische bewoning van een adres. Met de API ku
 ## Direct uitproberen?
 * Bekijk de specificaties met Redoc](https://brp-api.github.io/Haal-Centraal-BRP-bewoning/v2/redoc)
 * Lees de [Getting started](https://brp-api.github.io/Haal-Centraal-BRP-bewoning/v2/getting-started)
-* Download de [technische specificaties](https://github.com/BRP-API/Haal-Centraal-BRP-bewoning/blob/master/specificatie/genereervariant/openapi.yaml)
 
 ## Heb je meer nodig? 
 Gebruik de BRP bewoning API in combinatie met (een van de) andere BRP API’s:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Gebruik de BRP bewoning API in combinatie met (een van de) andere BRP API’s:
 
 ## Bronnen
 
-* [Productvisie Haal Centraal](https://vng-realisatie.github.io/Haal-Centraal)
 * [API Design Visie](https://github.com/Geonovum/KP-APIs/blob/master/overleggen/Werkgroep%20API%20design%20visie/API%20Design%20Visie.md)
 * [REST API Design Rules](https://docs.geostandaarden.nl/api/API-Designrules/)
 * [Landelijke API strategie voor de overheid](https://geonovum.github.io/KP-APIs/)

--- a/README.md
+++ b/README.md
@@ -3,21 +3,19 @@
 ![lint oas](https://github.com/BRP-API/Haal-Centraal-BRP-Bewoning/workflows/lint-oas/badge.svg)
 ![generate postman collection](https://github.com/BRP-API/Haal-Centraal-BRP-Bewoning/workflows/generate-postman-collection/badge.svg)
 
-API voor het raadplegen van de (historische) bewoning van een adres, verloop op een adres, of de medebewoners van een persoon.
-De API wordt nog niet door RvIG aangeboden. Om de migratie naar API's te versnellen besluiten sommige gemeenten de API zelf aan te bieden.  
+API voor het raadplegen van de historische bewoning van een adres. Met de API kun je de samenstelling(en) van bewoners van een woning raadplegen op een peildatum of binnen een periode.
 
 ## Direct uitproberen?
-* Bekijk de specificaties met [Swagger UI](https://vng-realisatie.github.io/Haal-Centraal-BRP-bevragen/swagger-ui) of [Redoc](https://vng-realisatie.github.io/Haal-Centraal-BRP-bevragen/redoc)
-* Lees de [Getting started](https://vng-realisatie.github.io/Haal-Centraal-BRP-bevragen/getting-started)
-* Download de [technische specificaties](https://github.com/BRP-API/Haal-Centraal-BRP-Bewoning/blob/master/specificatie/genereervariant/openapi.yaml)
+* Bekijk de specificaties met Redoc](https://brp-api.github.io/Haal-Centraal-BRP-bewoning/v2/redoc)
+* Lees de [Getting started](https://brp-api.github.io/Haal-Centraal-BRP-bewoning/v2/getting-started)
+* Download de [technische specificaties](https://github.com/BRP-API/Haal-Centraal-BRP-bewoning/blob/master/specificatie/genereervariant/openapi.yaml)
 
 ## Heb je meer nodig? 
 Gebruik de BRP bewoning API in combinatie met (een van de) andere BRP API’s:
 
-* [Actuele BRP-gegevens bevragen](https://BRP-API.github.io/Haal-Centraal-BRP-bevragen)
-* [Historische BRP-gegevens bevragen](https://BRP-API.github.io/Haal-Centraal-BRP-historie-bevragen)
+* [Personen bevragen](https://BRP-API.github.io/Haal-Centraal-BRP-bevragen)
+* [Historische bevragen](https://BRP-API.github.io/Haal-Centraal-BRP-historie-bevragen)
 * [Reisdocumenten bevragen](https://BRP-API.github.io/Haal-Centraal-Reisdocumenten-bevragen)
-* [Landelijke tabellen bevragen](https://BRP-API.github.io/Haal-Centraal-BRP-tabellen-bevragen)
 
 ## Bronnen
 
@@ -33,11 +31,9 @@ Gebruik de BRP bewoning API in combinatie met (een van de) andere BRP API’s:
 * Verbeteringen doorgeven
   [Maak een verbeter issue aan >>](https://github.com/BRP-API/Haal-Centraal-BRP-bewoning/issues/new?assignees=&labels=enhancement&template=enhancement.md&title=)
 
-* Product Owner: Cathy Dingemanse, [c.dingemanse@comites.nl](mailto:c.dingemanse@comites.nl)
-* Designer: Johan Boer, [johan.boer@vng.nl](mailto:johan.boer@vng.nl)
-* Designer: Robert Melskens, [robert.melskens@vng.nl](mailto:robert.melskens@vng.nl)
-* Customer zero: Melvin Lee, [melvin.lee@iswish.nl](mailto:melvin.lee@iswish.nl)
-* Tester: Frank Samwel, [frank.samwel@denhaag.nl](mailto:frank.samwel@denhaag.nl)
+* Product Owner: Cathy Dingemanse, [cathy.dingemanse@rvig.nl](mailto:cathy.dingemanse@rvig.nl)
+* Customer zero en ontwikkelaar: Melvin Lee, [melvin.lee@iswish.nl](mailto:melvin.lee@rvig.nl)
+* Tester: Frank Samwel, [frank.samwel@rvig.nl](mailto:frank.samwel@rvig.nl)
 
 ## Licentie
 Copyright &copy; VNG Realisatie 2020

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ API voor het raadplegen van de historische bewoning van een adres. Met de API ku
 Gebruik de BRP bewoning API in combinatie met (een van de) andere BRP API’s:
 
 * [Personen bevragen](https://BRP-API.github.io/Haal-Centraal-BRP-bevragen)
-* [Historische bevragen](https://BRP-API.github.io/Haal-Centraal-BRP-historie-bevragen)
+* [Historie bevragen](https://BRP-API.github.io/Haal-Centraal-BRP-historie-bevragen)
 * [Reisdocumenten bevragen](https://BRP-API.github.io/Haal-Centraal-Reisdocumenten-bevragen)
 
 ## Bronnen

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -33,7 +33,8 @@ nav:
   - title: Specificaties v. 2
     subnav:
       - title: Releasenotes
-        path: releasenotes
+        path: https://github.com/BRP-API/Haal-Centraal-BRP-bewoning/releases
+        target: blank
       - title: Getting started
         path: /v2/getting-started
       - title: User stories

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -37,7 +37,7 @@ nav:
       - title: Getting started
         path: /v2/getting-started
       - title: User stories
-        path: /user-stories-prod
+        path: /user-stories
       - title: Bevragen API (redoc)
         path: /v2/redoc
       - title: Bevragen API, GBA variant (redoc)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ API voor het raadplegen van de historische bewoning van een adres. Met de API ku
 De bewoning API v2 kan voorlopig alleen worden gebruikt door gemeenten. 
 
 ## Direct uitproberen?
-* Bekijk de specificaties met [Redoc](https://brp-api.github.io/Haal-Centraal-BRP-bewoning/redoc-io)
+* Bekijk de specificaties met [Redoc](https://brp-api.github.io/Haal-Centraal-BRP-bewoning/v2/redoc)
 * Lees de [Getting started](https://brp-api.github.io/Haal-Centraal-BRP-bewoning/v2/getting-started)
   
 ## Heb je meer nodig? 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,8 +22,6 @@ Gebruik de BRP bewoning API in combinatie met (een van de) andere BRP API’s:
 * [Personen bevragen](https://BRP-API.github.io/Haal-Centraal-BRP-bevragen){:target="_blank" rel="noopener"}
 * [Historie bevragen](https://BRP-API.github.io/Haal-Centraal-BRP-historie-bevragen){:target="_blank" rel="noopener"}
 * [Reisdocumenten bevragen](https://BRP-API.github.io/Haal-Centraal-Reisdocumenten-bevragen){:target="_blank" rel="noopener"}
-  
-Maak je nog gebruik van versie 1.0? Bekijk de specificaties met [Swagger UI](https://brp-api.github.io/Haal-Centraal-BRP-bewoning/swagger-ui) of [Redoc](https://brp-api.github.io/Haal-Centraal-BRP-bewoning/redoc) en download de [technische specificaties](https://github.com/BRP-API/Haal-Centraal-BRP-Bewoning/blob/master/specificatie/genereervariant/openapi.yaml)
 
 ## Bronnen
 

--- a/docs/redoc-gba-io.md
+++ b/docs/redoc-gba-io.md
@@ -1,8 +1,0 @@
----
-layout: page-with-side-nav
-title: redoc
-body_include: redoc-body.html
-spec-url: https://raw.githubusercontent.com/BRP-API/Haal-Centraal-BRP-bewoning/develop/specificatie/gba-genereervariant/openapi.yaml
----
-GBA variant versie 2.0.0 (IO)
-<redoc spec-url='{{ page.spec-url}}'></redoc>

--- a/docs/redoc-io.md
+++ b/docs/redoc-io.md
@@ -1,7 +1,0 @@
----
-layout: page-with-side-nav
-title: redoc
-body_include: redoc-body.html
-spec-url: https://raw.githubusercontent.com/BRP-API/Haal-Centraal-BRP-bewoning/develop/specificatie/genereervariant/openapi.yaml
----
-<redoc spec-url='{{ page.spec-url}}'></redoc>

--- a/docs/redoc.md
+++ b/docs/redoc.md
@@ -1,7 +1,0 @@
----
-layout: page-with-side-nav
-title: redoc
-body_include: redoc-body.html
-spec-url: https://raw.githubusercontent.com/BRP-API/Haal-Centraal-BRP-bewoning/master/specificatie/genereervariant/openapi.yaml
----
-<redoc spec-url='{{ page.spec-url}}'></redoc>

--- a/docs/swagger-ui.md
+++ b/docs/swagger-ui.md
@@ -1,8 +1,0 @@
----
-layout: page-with-side-nav
-title: swagger-ui
-head_include: swagger-ui-head.html
-body_include: swagger-ui-body.html
-openapi-url:  https://raw.githubusercontent.com/BRP-API/Haal-Centraal-BRP-bewoning/master/specificatie/genereervariant/openapi.yaml
----
-<div id="swagger-ui"></div>


### PR DESCRIPTION
- README.md rechtgetrokken met index.md
- de user stories overzicht staat in de user-stories.md. De navigatie menu is hierop aangepast
- de release notes navigatie menu verwijst nu naar: https://github.com/BRP-API/Haal-Centraal-BRP-bewoning/releases
- oude redoc en swagger-ui pagina's en verwijzingen verwijderd