### PR TITLE
rule en scenario voor aansluitende periodes zelfde bewonerssamenstelling

### DIFF
--- a/features/raadpleeg-bewoning-met-periode/gba/bewoning-samenstellingen-mogelijke-bewoners-gba.feature
+++ b/features/raadpleeg-bewoning-met-periode/gba/bewoning-samenstellingen-mogelijke-bewoners-gba.feature
@@ -437,3 +437,33 @@ Functionaliteit: Bewoningsamenstellingen met mogelijke bewoners
       En heeft de bewoning een mogelijke bewoner met de volgende gegevens
       | burgerservicenummer |
       | 000000012           |
+
+  Rule: Aaneensluitende periodes met identieke samenstelling van bewoners en mogelijke bewoners worden geleverd als één bewoning
+
+    Abstract Scenario: persoon heeft onbekende aanvang adreshouding en daar direct op aansluitende onbekende aanvang volgende adreshouding en periode overlapt de onzekerheidsperiodes
+      Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | <datum aanvang adreshouding>       |
+      En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30)    |
+      | 0800                              | <datum aanvang volgende adreshouding> |
+      Als gba bewoning wordt gezocht met de volgende parameters
+      | naam                             | waarde             |
+      | type                             | BewoningMetPeriode |
+      | datumVan                         | 2009-07-01         |
+      | datumTot                         | 2011-07-01         |
+      | adresseerbaarObjectIdentificatie | 0800010000000001   |
+      Dan heeft de response een bewoning met de volgende gegevens
+      | naam                             | waarde                      |
+      | periode                          | <datum van> tot <datum tot> |
+      | adresseerbaarObjectIdentificatie | 0800010000000001            |
+      En heeft de bewoning een mogelijke bewoner met de volgende gegevens
+      | burgerservicenummer |
+      | 000000024           |
+
+      Voorbeelden:
+      | datum aanvang adreshouding | datum aanvang volgende adreshouding | datum van  | datum tot  |
+      | 20100800                   | 20100900                            | 2010-08-01 | 2010-10-01 |
+      | 20101200                   | 20110000                            | 2010-12-01 | 2012-01-01 |
+      | 20100000                   | 20110100                            | 2010-01-01 | 2011-02-01 |
+      | 20100000                   | 20110000                            | 2010-01-01 | 2012-01-01 |


### PR DESCRIPTION
bij aaneensluitende periodes met zelfde bewonerssamenstelling worden volgens de huidige feature bewonerssamenstellingen twee bewoningen geleverd met aansluitende periodes en identieke samenstelling van (mogelijke) bewoners.

De rule die ik hier toevoeg stelt dat dit als één bewoning geleverd moet worden.

@CathyDingemanse wat nu geleverd wordt is niet echt fout, wel onnodige opsplitsing van een bewoning in twee bewoningen